### PR TITLE
Worktree per bench isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ benchmark                   avg (min … max) p75 / p99    (min … top 1%)
 
 Labs promises to give results you can trust. To do this we make a number of guarantees when running benches.
 
-- Each bench runs in its own isolated worker process, preventing benches in the same file from contaminating each other's JIT state, heap layout, or GC history. Reordering benches can otherwise skew results by 2× or more. Opt out with `isolate: false` or `--no-isolate`.
+- Each bench runs in its own isolated worker process, preventing benches in the same file from contaminating each other's JIT state, heap layout, or GC history. Reordering benches can otherwise skew results by 2× or more. Opt out with `isolate: false` in the config or `--no-isolate` in the CLI.
 - CPU clock speed is measured before and after the run. If it drifts, Labs flags the result so it doesn't pollute comparisons.
 - Adaptive sampling continues until the confidence interval converges, or marks the bench `noisy` if it can't. This usually means the bench contains some random element and is not deterministic.
 - Each sample starts with a garbage collection (GC) reset so previous samples don't affect it.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ group('array @stress', () => {
 
 ### Run
 
-Each bench runs in an isolated worker process. CPU clock speed is measured before and after the run and if it drifts, Labs flags the result so it doesn't pollute comparisons. Adaptive sampling collects more samples until the confidence interval converges, or marks the bench `noisy` if it can't. Each sample has garbage collection (GC) reset so previous runs do not pollute it while measuring its impact.
+Each bench runs in its own isolated worker process, so benches in the same file can't contaminate each other's JIT state (shared inline caches going polymorphic, heap layout, GC history) — without this, reordering benches in a file can skew results by 2× or more (opt out with `isolate: false` or `--no-isolate`). CPU clock speed is measured before and after the run and if it drifts, Labs flags the result so it doesn't pollute comparisons. Adaptive sampling collects more samples until the confidence interval converges, or marks the bench `noisy` if it can't. Each sample has garbage collection (GC) reset so previous runs do not pollute it while measuring its impact.
 
 ```sh
 # Run all benches, save named after the current commit
@@ -138,6 +138,7 @@ pnpm bench --baseline                   # save and set as baseline
 pnpm bench -b                           # shorthand for --baseline
 pnpm bench -n "v1.2.0" -b              # save with name and set as baseline
 pnpm bench --compare                    # save, then compare vs baseline
+pnpm bench --no-isolate                 # share one process per file (skip per-bench isolation)
 pnpm bench -c                           # shorthand for --compare
 pnpm bench --last                       # rerun previous selection, save
 ```
@@ -292,6 +293,7 @@ export default defineConfig({
 | `alpha` | `0.05` | Mann-Whitney U significance level |
 | `minDelta` | `0.05` | Floor for the noise-adjusted ±Δ threshold; the effective threshold per bench is `max(minDelta, 3 × relative MAD)` |
 | `minEffect` | `0.474` | Minimum | Cliff's d | to flag a verdict; filters noise on high-variance benches where distributions overlap |
+| `isolate` | `true` | Run each bench in its own fresh worker process so benches can't contaminate each other's JIT/heap state (order-dependent results); `false` shares one process per file |
 
 Sampling behavior:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ group('array @stress', () => {
 
 ### Run
 
-Each bench runs in its own isolated worker process, so benches in the same file can't contaminate each other's JIT state (shared inline caches going polymorphic, heap layout, GC history) — without this, reordering benches in a file can skew results by 2× or more (opt out with `isolate: false` or `--no-isolate`). CPU clock speed is measured before and after the run and if it drifts, Labs flags the result so it doesn't pollute comparisons. Adaptive sampling collects more samples until the confidence interval converges, or marks the bench `noisy` if it can't. Each sample has garbage collection (GC) reset so previous runs do not pollute it while measuring its impact.
+Run your benchmarks with the `bench` command.
 
 ```sh
 # Run all benches, save named after the current commit
@@ -71,10 +71,24 @@ benchmark                   avg (min … max) p75 / p99    (min … top 1%)
                 heap( 41.19 mb …  50.10 mb)  47.63 mb/iter
 ```
 
+<details>
+<summary>How to read the results</summary>
+
 - `avg/iter p75`: Average time per iteration and p75, this is the most useful top metric.
-- `(min … max) p99`: Fastest, slowest, and tail time that 99% of samples finish within. This tells you the distrubtion which is visualized by the histogram.
+- `(min … max) p99`: Fastest, slowest, and tail time that 99% of samples finish within. This shows the distribution visualized by the histogram.
 - `gc(min … max) avg`: Time spent collecting after each sample. Higher times usually mean the bench keeps more objects alive.
 - `heap(min … max) avg/iter`: Bytes allocated per iteration before collection. Higher values mean more garbage for the runtime to clean up.
+
+</details>
+
+#### Guarantees
+
+Labs promises to give results you can trust. To do this we make a number of guarantees when running benches.
+
+- Each bench runs in its own isolated worker process, preventing benches in the same file from contaminating each other's JIT state, heap layout, or GC history. Reordering benches can otherwise skew results by 2× or more. Opt out with `isolate: false` or `--no-isolate`.
+- CPU clock speed is measured before and after the run. If it drifts, Labs flags the result so it doesn't pollute comparisons.
+- Adaptive sampling continues until the confidence interval converges, or marks the bench `noisy` if it can't. This usually means the bench contains some random element and is not deterministic.
+- Each sample starts with a garbage collection (GC) reset so previous samples don't affect it.
 
 ### Compare
 

--- a/src/bench/main.ts
+++ b/src/bench/main.ts
@@ -310,6 +310,47 @@ function defaults(opts: any): void {
   opts.colors ??= colors();
   opts.tune ??= {};
   opts.observe ??= (trial: any) => trial;
+  opts.run_trial ??= (trial: B, _index: number) => trial.run(opts.throw, opts.tune);
+}
+
+/**
+ * Load `@mitata/counters` when the platform supports it. Hardware counter
+ * state is per-process, so isolated bench workers call this on their own.
+ */
+async function initCounters(arch: string | null, runtime: string | null): Promise<void> {
+  if ($counters || !['bun', 'node', 'deno'].includes(runtime as string)) return;
+
+  if (arch?.includes?.('darwin')) {
+    try {
+      const _c = '@mitata/counters';
+      $counters = await import(_c);
+      if (0 !== (globalThis as any).process.getuid()) throw (($counters = false), 1);
+    } catch {}
+  }
+
+  if (!$counters && arch?.includes?.('linux')) {
+    try {
+      const _c = '@mitata/counters';
+      $counters = await import(_c);
+    } catch (err: any) {
+      if (err?.message?.includes?.('PermissionDenied')) $counters = false;
+    }
+  }
+}
+
+/**
+ * Run a single registered trial by global registration index (the order
+ * `bench()` calls executed, across all collections). Entry point for isolated
+ * per-bench child workers: skips context calibration and rendering entirely.
+ */
+export async function runTrialAt(index: number, tune: any = {}): Promise<Trial> {
+  const trials = COLLECTIONS.flatMap((c) => c.trials) as B[];
+  const trial = trials[index];
+  if (!trial) {
+    throw new RangeError(`no bench registered at index ${index} (${trials.length} registered)`);
+  }
+  await initCounters(await arch(), runtime());
+  return await trial.run(false, tune);
 }
 
 export async function run(
@@ -344,30 +385,7 @@ export async function run(
     },
   };
 
-  if (
-    !$counters &&
-    context.arch?.includes?.('darwin') &&
-    ['bun', 'node', 'deno'].includes(context.runtime as string)
-  ) {
-    try {
-      const _c = '@mitata/counters';
-      $counters = await import(_c);
-      if (0 !== (globalThis as any).process.getuid()) throw (($counters = false), 1);
-    } catch {}
-  }
-
-  if (
-    !$counters &&
-    context.arch?.includes?.('linux') &&
-    ['bun', 'node', 'deno'].includes(context.runtime as string)
-  ) {
-    try {
-      const _c = '@mitata/counters';
-      $counters = await import(_c);
-    } catch (err: any) {
-      if (err?.message?.includes?.('PermissionDenied')) $counters = false;
-    }
-  }
+  await initCounters(context.arch, context.runtime);
 
   const layout = COLLECTIONS.map((c) => ({ name: c.name, types: c.types }));
   const format = 'string' === typeof opts.format ? opts.format : Object.keys(opts.format)[0];
@@ -385,10 +403,12 @@ export async function run(
 
 const formats = {
   async quiet(_: any, opts: any, benchmarks: Trial[]) {
+    let index = 0;
     for (const collection of COLLECTIONS) {
       for (const trial of collection.trials) {
+        const i = index++;
         if (opts.filter.test(trial._name))
-          benchmarks.push(opts.observe(await trial.run(opts.throw, opts.tune)));
+          benchmarks.push(opts.observe(await opts.run_trial(trial, i)));
       }
     }
   },
@@ -398,10 +418,12 @@ const formats = {
     const debug = opts.format?.debug ?? true;
     const samples = opts.format?.samples ?? true;
 
+    let index = 0;
     for (const collection of COLLECTIONS) {
       for (const trial of collection.trials) {
+        const i = index++;
         if (opts.filter.test(trial._name))
-          benchmarks.push(opts.observe(await trial.run(opts.throw, opts.tune)));
+          benchmarks.push(opts.observe(await opts.run_trial(trial, i)));
       }
     }
 
@@ -434,13 +456,15 @@ const formats = {
 
     print('');
 
+    let index = 0;
     for (const collection of COLLECTIONS) {
       const trials: Trial[] = [];
       if (!collection.trials.length) continue;
 
       for (const trial of collection.trials) {
+        const i = index++;
         if (opts.filter.test(trial._name)) {
-          let bench = await trial.run(opts.throw, opts.tune);
+          let bench = await opts.run_trial(trial, i);
 
           bench = opts.observe(bench);
           trials.push(bench);
@@ -485,11 +509,13 @@ const formats = {
   async mitata(ctx: any, opts: any, benchmarks: Trial[]) {
     const renderedCollections: RenderedCollection[] = [];
 
+    let index = 0;
     for (const collection of COLLECTIONS) {
       const renderedTrials: RenderedCollection['trials'] = [];
       for (const trial of collection.trials) {
+        const i = index++;
         if (!opts.filter.test(trial._name)) continue;
-        let bench = await trial.run(opts.throw, opts.tune);
+        let bench = await opts.run_trial(trial, i);
         bench = opts.observe(bench);
         benchmarks.push(bench);
         renderedTrials.push({

--- a/src/bench/types.ts
+++ b/src/bench/types.ts
@@ -45,15 +45,7 @@ export type FnKind = 'fn' | 'iter' | 'yield';
 export type GcMode = boolean | 'once' | 'inner';
 
 export type Color =
-  | 'red'
-  | 'cyan'
-  | 'blue'
-  | 'green'
-  | 'yellow'
-  | 'magenta'
-  | 'gray'
-  | 'white'
-  | 'black';
+  'red' | 'cyan' | 'blue' | 'green' | 'yellow' | 'magenta' | 'gray' | 'white' | 'black';
 
 export interface Run {
   stats?: Stats;
@@ -94,6 +86,12 @@ export interface RunOptions {
   tune?: MeasureOptions;
   calibrate?: MeasureOptions;
   format?: string | Record<string, any>;
+  /**
+   * Executes one registered trial; defaults to running it in-process.
+   * `index` is the trial's global registration order. Isolated workers
+   * override this to delegate each trial to a fresh child process.
+   */
+  run_trial?: (trial: any, index: number) => Trial | Promise<Trial>;
 }
 
 export interface Collection {

--- a/src/bench/worker.ts
+++ b/src/bench/worker.ts
@@ -1,6 +1,11 @@
-import { writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { getBenchRegistry } from '../index.ts';
 import { measure, run } from './index.ts';
+import { runTrialAt } from './main.ts';
+import type { Trial } from './types.ts';
 
 type TuneOptions = {
   min_cpu_time?: number;
@@ -47,9 +52,51 @@ async function calibrateFreq(): Promise<number> {
   return 1 / (r as any).avg;
 }
 
-async function main(): Promise<void> {
+/** Serializes Error instances the same way the `json` format does. */
+function errorReplacer(_: string, v: any): any {
+  if (!(v instanceof Error)) return v;
+  return { message: String(v.message), stack: v.stack };
+}
+
+/**
+ * Child mode: measure a single trial in this fresh process and write it out.
+ * Skips calibration and rendering — the parent worker owns both.
+ */
+async function childMain(index: number): Promise<void> {
   await import(file!);
-  const result = await run({ tune: parseTuneEnv() });
+  const trial = await runTrialAt(index, parseTuneEnv());
+  writeFileSync(process.env.LABS_RESULT_FILE!, JSON.stringify({ trial }, errorReplacer));
+}
+
+/**
+ * Runs one trial in a fresh child process (same script, same node flags,
+ * `LABS_ONLY_INDEX` selecting the trial) so each bench measures against a
+ * pristine V8 — no IC/heap contamination from earlier benches in the file.
+ */
+function runTrialIsolated(trial: any, index: number): Trial {
+  const resultFile = join(tmpdir(), `labs-trial-${process.pid}-${index}.json`);
+  try {
+    execFileSync(process.execPath, [...process.execArgv, process.argv[1]], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+      env: { ...process.env, LABS_ONLY_INDEX: String(index), LABS_RESULT_FILE: resultFile },
+    });
+    return JSON.parse(readFileSync(resultFile, 'utf-8')).trial;
+  } catch (err) {
+    throw new Error(`isolated bench "${trial?._name ?? index}" failed: ${String(err)}`, {
+      cause: err,
+    });
+  } finally {
+    rmSync(resultFile, { force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  const isolate = process.env.LABS_ISOLATE !== 'false';
+  await import(file!);
+  const result = await run({
+    tune: parseTuneEnv(),
+    ...(isolate ? { run_trial: runTrialIsolated } : {}),
+  });
   const postFreq = await calibrateFreq();
 
   const registry = getBenchRegistry();
@@ -60,9 +107,10 @@ async function main(): Promise<void> {
   if (process.env.LABS_RESULT_FILE) {
     writeFileSync(
       process.env.LABS_RESULT_FILE,
-      JSON.stringify({ ...result, environment: { postFreq } })
+      JSON.stringify({ ...result, environment: { postFreq } }, errorReplacer)
     );
   }
 }
 
-void main();
+const onlyIndex = process.env.LABS_ONLY_INDEX;
+void (onlyIndex !== undefined ? childMain(Number(onlyIndex)) : main());

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -98,7 +98,7 @@ function runBench(
   label: string,
   tune: Pick<
     Partial<LabsConfig>,
-    'minCpuTime' | 'minSamples' | 'maxSamples' | 'adaptive' | 'maxCpuTime'
+    'minCpuTime' | 'minSamples' | 'maxSamples' | 'adaptive' | 'maxCpuTime' | 'isolate'
   >,
   tagFilter?: string,
   resultFile?: string
@@ -114,6 +114,7 @@ function runBench(
       ...(tune.maxSamples !== undefined ? { LABS_MAX_SAMPLES: String(tune.maxSamples) } : {}),
       ...(tune.adaptive !== undefined ? { LABS_ADAPTIVE: String(tune.adaptive) } : {}),
       ...(tune.maxCpuTime !== undefined ? { LABS_MAX_CPU_TIME: String(tune.maxCpuTime * 1e9) } : {}),
+      ...(tune.isolate === false ? { LABS_ISOLATE: 'false' } : {}),
       ...(tagFilter ? { LABS_GREP_TAGS: tagFilter } : {}),
       ...(resultFile ? { LABS_RESULT_FILE: resultFile } : {}),
     },
@@ -282,26 +283,23 @@ export async function runCLI(args: string[]) {
     console.log(`${CYAN}labs${RESET}`);
   }
 
+  const isolate = config.isolate !== false && !benchArgs.includes('--no-isolate');
+  const benchTune = {
+    minCpuTime: config.minCpuTime,
+    minSamples: config.minSamples,
+    maxSamples: config.maxSamples,
+    adaptive: config.adaptive,
+    maxCpuTime: config.maxCpuTime,
+    isolate,
+  };
+
   if (!shouldSave) {
     const tmpDir = join(cwd, 'node_modules', '.cache', 'labs-tmp');
     mkdirSync(tmpDir, { recursive: true });
     const runOutputs: Array<{ file: string; resultFile: string }> = [];
     for (const f of selected) {
       const resultFile = join(tmpDir, `${basename(f, '.ts')}-${Date.now()}.json`);
-      runBench(
-        f,
-        config.nodeFlags,
-        suiteName(f),
-        {
-          minCpuTime: config.minCpuTime,
-          minSamples: config.minSamples,
-          maxSamples: config.maxSamples,
-          adaptive: config.adaptive,
-          maxCpuTime: config.maxCpuTime,
-        },
-        tagEnv,
-        resultFile
-      );
+      runBench(f, config.nodeFlags, suiteName(f), benchTune, tagEnv, resultFile);
       runOutputs.push({ file: f, resultFile });
     }
     const runEnvData: FreqSample[] = [];
@@ -352,20 +350,7 @@ export async function runCLI(args: string[]) {
   const workerOutputs: Array<{ file: string; resultFile: string }> = [];
   for (const f of selected) {
     const resultFile = join(tmpDir, `${basename(f, '.ts')}-${Date.now()}.json`);
-    runBench(
-      f,
-      config.nodeFlags,
-      suiteName(f),
-      {
-        minCpuTime: config.minCpuTime,
-        minSamples: config.minSamples,
-        maxSamples: config.maxSamples,
-        adaptive: config.adaptive,
-        maxCpuTime: config.maxCpuTime,
-      },
-      tagEnv,
-      resultFile
-    );
+    runBench(f, config.nodeFlags, suiteName(f), benchTune, tagEnv, resultFile);
     workerOutputs.push({ file: f, resultFile });
   }
 
@@ -435,6 +420,7 @@ export async function runCLI(args: string[]) {
     timestamp: new Date().toISOString(),
     ...(git ? { git } : {}),
     hardware,
+    isolation: isolate ? 'bench' : 'file',
     context: savedNoop,
     files,
     environment: { freqs: saveEnvData },

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -104,17 +104,27 @@ function runBench(
   resultFile?: string
 ): void {
   console.log(`\n${BLUE}▶ ${label}${RESET}`);
+
+  // The runner is the only source of truth for worker control variables:
+  // scrub inherited LABS_* so a leaked shell export can't silently change
+  // worker behavior (or worse, contradict the isolation mode recorded in
+  // the saved result).
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('LABS_')) delete env[key];
+  }
+
   execFileSync(process.execPath, ['--import', TSX_LOADER, ...nodeFlags, WORKER], {
     stdio: 'inherit',
     env: {
-      ...process.env,
+      ...env,
       LABS_BENCH_FILE: pathToFileURL(file).href,
+      LABS_ISOLATE: String(tune.isolate !== false),
       ...(tune.minCpuTime !== undefined ? { LABS_MIN_CPU_TIME: String(tune.minCpuTime * 1e9) } : {}),
       ...(tune.minSamples !== undefined ? { LABS_MIN_SAMPLES: String(tune.minSamples) } : {}),
       ...(tune.maxSamples !== undefined ? { LABS_MAX_SAMPLES: String(tune.maxSamples) } : {}),
       ...(tune.adaptive !== undefined ? { LABS_ADAPTIVE: String(tune.adaptive) } : {}),
       ...(tune.maxCpuTime !== undefined ? { LABS_MAX_CPU_TIME: String(tune.maxCpuTime * 1e9) } : {}),
-      ...(tune.isolate === false ? { LABS_ISOLATE: 'false' } : {}),
       ...(tagFilter ? { LABS_GREP_TAGS: tagFilter } : {}),
       ...(resultFile ? { LABS_RESULT_FILE: resultFile } : {}),
     },

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -89,7 +89,17 @@ export const warnClockDrift: EnvironmentWarning = (baseline, candidate) => {
   return warnings;
 };
 
-export const ENVIRONMENT_WARNINGS: EnvironmentWarning[] = [warnClockDrift];
+export const warnIsolationMismatch: EnvironmentWarning = (baseline, candidate) => {
+  const b = baseline.isolation ?? 'file';
+  const c = candidate.isolation ?? 'file';
+  if (b === c) return [];
+  return [
+    `runs used different bench isolation (baseline: per-${b}, candidate: per-${c}) — ` +
+      `benches sharing a process inherit each other's JIT/heap state, so absolute numbers may not be comparable`,
+  ];
+};
+
+export const ENVIRONMENT_WARNINGS: EnvironmentWarning[] = [warnClockDrift, warnIsolationMismatch];
 
 /** All environment checks in order. Any failure blocks the entire comparison. */
 export const ENVIRONMENT_CHECKS: EnvironmentCheck[] = [checkHardwareMatch];

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,14 @@ export interface LabsConfig {
   minDelta: number;
   /** Minimum |Cliff's d| required to flag a verdict. Filters noise on high-variance benches where distributions overlap despite a median shift. @default 0.474 */
   minEffect: number;
+  /**
+   * Run each bench in its own fresh worker process. Prevents order-dependent
+   * contamination between benches in a file (shared inline caches, heap
+   * layout, GC history — measured up to 2.4× skew). `false` reverts to one
+   * process per file, for suites that rely on shared in-process state or have
+   * expensive top-level setup. @default true
+   */
+  isolate?: boolean;
 }
 
 export function defineConfig(config: Partial<LabsConfig> & Pick<LabsConfig, 'benchDir'>): LabsConfig {
@@ -41,6 +49,7 @@ export function defineConfig(config: Partial<LabsConfig> & Pick<LabsConfig, 'ben
     alpha: 0.05,
     minDelta: 0.05,
     minEffect: 0.474,
+    isolate: true,
     ...config,
   };
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -125,6 +125,11 @@ export interface SavedResult {
   timestamp: string;
   git?: GitInfo;
   hardware: HardwareInfo;
+  /**
+   * Bench isolation mode the run used: 'bench' = fresh process per bench,
+   * 'file' = one process per file. Absent on legacy results (implies 'file').
+   */
+  isolation?: 'bench' | 'file';
   context?: {
     version?: string | null;
     noop?: {

--- a/tests/fixtures/isolation.bench.ts
+++ b/tests/fixtures/isolation.bench.ts
@@ -1,0 +1,18 @@
+import { bench, group } from '../../src/index.ts';
+
+// Module state acts as a contamination detector: in a shared process the
+// polluter's writes are visible to the victim; in per-bench isolation each
+// bench imports this module fresh and the flag is always false.
+let polluted = false;
+
+group('isolation', () => {
+  bench('polluter', () => {
+    polluted = true;
+    return 1;
+  });
+
+  bench('victim', () => {
+    if (polluted) throw new Error('shared process state leaked between benches');
+    return 1;
+  });
+});

--- a/tests/isolation.test.ts
+++ b/tests/isolation.test.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { bench, group, runTrialAt } from '../src/bench/main.ts';
+
+const fast = { min_cpu_time: 1, min_samples: 12, adaptive: false } as const;
+
+describe('runTrialAt', () => {
+  it('addresses trials by global registration order across groups', async () => {
+    let plainRan = 0;
+    let groupedRan = 0;
+
+    bench('plain', () => plainRan++);
+    void group('a group', () => {
+      bench('grouped first', () => 1);
+      bench('grouped second', () => groupedRan++);
+    });
+
+    const trial = await runTrialAt(2, fast);
+
+    expect(trial.alias).toBe('grouped second');
+    expect(groupedRan).toBeGreaterThan(0);
+    expect(plainRan).toBe(0);
+    expect(trial.runs[0].stats?.samples.length).toBeGreaterThan(0);
+
+    await expect(runTrialAt(3, fast)).rejects.toThrow(RangeError);
+  });
+});
+
+describe('worker bench isolation', () => {
+  const WORKER = fileURLToPath(new URL('../src/worker.ts', import.meta.url));
+  const FIXTURE = fileURLToPath(new URL('./fixtures/isolation.bench.ts', import.meta.url));
+  const TSX = pathToFileURL(createRequire(import.meta.url).resolve('tsx')).href;
+  let spawnCount = 0;
+
+  function runWorker(env: Record<string, string>) {
+    const resultFile = join(tmpdir(), `labs-isolation-test-${process.pid}-${spawnCount++}.json`);
+    try {
+      execFileSync(process.execPath, ['--import', TSX, WORKER], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        env: {
+          ...process.env,
+          LABS_BENCH_FILE: pathToFileURL(FIXTURE).href,
+          LABS_RESULT_FILE: resultFile,
+          LABS_MIN_CPU_TIME: '1',
+          LABS_MIN_SAMPLES: '12',
+          LABS_ADAPTIVE: 'false',
+          ...env,
+        },
+      });
+      return JSON.parse(readFileSync(resultFile, 'utf-8'));
+    } finally {
+      rmSync(resultFile, { force: true });
+    }
+  }
+
+  it(
+    "keeps benches from observing each other's process state by default",
+    { timeout: 60_000 },
+    () => {
+      const result = runWorker({});
+      const [polluter, victim] = result.benchmarks;
+
+      expect(result.benchmarks).toHaveLength(2);
+      expect(polluter.runs[0].stats.samples.length).toBeGreaterThan(0);
+      // In a shared process the victim throws; in a fresh process it measures.
+      expect(victim.runs[0].error).toBeUndefined();
+      expect(victim.runs[0].stats.samples.length).toBeGreaterThan(0);
+      // groupName zipping via the registry still works with delegated trials.
+      expect(victim.groupName).toBe('isolation');
+    }
+  );
+
+  it('shares one process per file when ejected via LABS_ISOLATE=false', { timeout: 60_000 }, () => {
+    const result = runWorker({ LABS_ISOLATE: 'false' });
+    const [polluter, victim] = result.benchmarks;
+
+    expect(polluter.runs[0].stats.samples.length).toBeGreaterThan(0);
+    expect(victim.runs[0].error?.message).toContain('leaked');
+    expect(victim.runs[0].stats).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Isolates every bench from each other so that they cannot pollute each other's JIT state, heap layout, or GC history.