### PR TITLE
Use block interleaving for more accurate comparisons

### DIFF
--- a/.config/vitest.config.ts
+++ b/.config/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// Tests measure real timing and spawn CPU-saturating bench workers, so test
+// files must not compete for cores. Serial execution keeps timings stable.
+export default defineConfig({
+  test: {
+    fileParallelism: false,
+    testTimeout: 20_000,
+  },
+});

--- a/README.md
+++ b/README.md
@@ -76,22 +76,10 @@ benchmark                   avg (min … max) p75 / p99    (min … top 1%)
 
 - `avg/iter p75`: Average time per iteration and p75, this is the most useful top metric.
 - `(min … max) p99`: Fastest, slowest, and tail time that 99% of samples finish within. This shows the distribution visualized by the histogram.
-- `gc(min … max) avg`: Time spent collecting after each sample. Higher times usually mean the bench keeps more objects alive.
+- `gc(min … max) avg`: Time spent in per-sample garbage collection. Higher times usually mean the bench keeps more objects alive.
 - `heap(min … max) avg/iter`: Bytes allocated per iteration before collection. Higher values mean more garbage for the runtime to clean up.
 
 </details>
-
-#### Guarantees
-
-Labs promises to give results you can trust. To do this a number of guarantees are made when running benches.
-
-- Each bench runs in its own isolated worker process, preventing benches in the same file from contaminating each other's JIT state, heap layout, or GC history. Reordering benches can otherwise skew results by 2x or more. Opt out with `isolate: false` in the config or `--no-isolate` in the CLI.
-- GC influence is mitigated. Each sample starts with a garbage collection (GC) reset so previous samples don't affect it.
-- Benches are run in blocks that are interleaved: `A₁ B₁ C₁ → A₂ B₂ C₂ → … → A₈ B₈ C₈`. This reduces bias from gradual changes such as CPU throttling or even boosting.
-- Timing overhead is controlled. If a sample's measurement time is so fast that the overhead of the timing itself would bias the results then it is run in a batch.
-- Detect dead code elimination (DCE). If the samples measure the same as an empty function call then we detect DCE and report it. This can be mitigated by returning a result inside the yield.
-- Detect if a bench is unstable. Samples are taken for a bench run until it settles into stastical significance. If this fails, a warning is given. This likely means the bench is non-determinstic.
-- Machine stability is measured. When the median timings between the interleaved runs is unstable, a warning is also given. This usually means the machine is too unstable to give useful measurements.
 
 ### Compare
 
@@ -106,20 +94,32 @@ And see the results!
 ```bash
 ━━ compare 2026-03-20_16-25-36 -> 2026-03-20_16-36-12
 Apple M4 Pro
-Mann-Whitney U  α=0.05  minΔ=5%  cliff's d≥0.474
+Mann-Whitney U on block medians  α=0.05  minΔ=5%
 
 relation-churn.bench.ts
-  bench                                    baseline  candidate    Δp50    Δp99     p
-------------------------------------------------------------------------------------
+  bench                                    baseline  candidate    Δp50    Δp99     p       Δ 95% CI
+---------------------------------------------------------------------------------------------------
   • relation churn
-  ----------------------------------------------------------------------------------
-  ■ big test                                17.96ms    17.74ms   -1.2%   +0.1%  .003
+  -------------------------------------------------------------------------------------------------
+  ▲ big test                                17.96ms    16.15ms  -10.1%   -9.8% <.001    -11.4..-8.8%
                                          ▁▂▄▅▅█▇▅▅▃ ▃▅▅██▅█▄▂▂
 ```
 
+## Guarantees
+
+Labs promises to give results you can trust. To do this a number of guarantees are made when running benches.
+
+- Each bench block runs in its own isolated worker process, preventing benches in the same file from contaminating each other's JIT state, heap layout, or GC history. Reordering benches can otherwise skew results by 2x or more. Opt out with `isolate: false` in the config or `--no-isolate` in the CLI.
+- GC influence is mitigated. By default, each sample starts with a garbage collection (GC) reset so previous samples don't affect it.
+- Saved benches are run in blocks that are interleaved: `A₁ B₁ C₁ → A₂ B₂ C₂ → … → A₈ B₈ C₈`. This reduces bias from gradual changes such as CPU throttling or even boosting.
+- Timing overhead is controlled. If a sample's measurement time is so fast that the overhead of the timing itself would bias the results, then it is run in a batch.
+- Detect dead code elimination (DCE). If the samples measure the same as an empty function call, then we detect DCE and report it. This can be mitigated by returning a result from the yielded function.
+- Detect if a bench has unstable samples. Samples are taken until the configured uncertainty target is reached. If this fails, a warning is given. This likely means the bench is non-deterministic or affected by runtime interference like background processes.
+- Machine stability is measured. When median timings vary too much across blocks of samples, a warning is given. This can indicate an unstable machine ranging from thermal throttling to background processes.
+
 ## How to control my CPU
 
-One the largest sources of noise when running benchmarks is an unstable environment and the usual culprit is the CPU. The CPU turbos or thermal throttles, or a process gest put on a P-core (performance) instead of an E-core (efficiency). Koota checks the CPU clocks before and after each bench and tracks if it is varying across the runs. If it detects too muc variance you will get warned and the run flagged. But what can you do about it?
+One of the largest sources of noise when running benchmarks is an unstable environment, and the usual culprit is the CPU. The CPU boosts or thermal throttles, or a process gets put on a P-core (performance) instead of an E-core (efficiency). Labs checks the CPU clocks before and after each benchmark file and before each block, and tracks whether they vary across the runs. If it detects too much variance, you will get warned and the run will be flagged. But what can you do about it?
 
 ### Windows
 
@@ -137,7 +137,12 @@ While Apple Silicon is relatively stable, there isn't much that can be done to c
 
 Linux gives the most controls getting the best possible environment for testing. [See this LLVM guide for specifics.](https://llvm.org/docs/Benchmarking.html#linux)
 
-## API report (to be edited)
+---
+
+> [!CAUTION]
+> Below are AI generated docs that will get edited eventually. For now it lives here as notes.
+
+## API
 
 Every run saves results by default, named after the current commit (`abc1234`, with `-dirty` when the tree has uncommitted changes, and a counter for repeat runs: `abc1234-2`). Outside a git repo, names fall back to a timestamp. Each result also records the commit, branch, and dirty state it was produced from. Use `bench run` to execute without saving.
 
@@ -156,6 +161,7 @@ pnpm bench -b                           # shorthand for --baseline
 pnpm bench -n "v1.2.0" -b              # save with name and set as baseline
 pnpm bench --compare                    # save, then compare vs baseline
 pnpm bench --no-isolate                 # share one process per file (skip per-bench isolation)
+pnpm bench --blocks 12                  # save with 12 fresh-process blocks per benchmark
 pnpm bench -c                           # shorthand for --compare
 pnpm bench --last                       # rerun previous selection, save
 ```
@@ -168,6 +174,7 @@ Results are saved to `<benchDir>/.labs/results/<name>.json` and include hardware
 pnpm bench run                          # run all, no save
 pnpm bench run "relation"              # filtered, no save
 pnpm bench run "@relation"             # filtered by tag, no save
+pnpm bench run --blocks 8              # no save, but use interleaved block sampling
 pnpm bench run --last                  # replay last selection, no save
 ```
 
@@ -202,16 +209,16 @@ pnpm bench compare -l                 # shorthand for --last
 
 Outputs a colored table for each eligible benchmark:
 
-| Column    | Description                                                                                            |
-| --------- | ------------------------------------------------------------------------------------------------------ |
-| baseline  | Median of the baseline's fresh-process block medians                                                   |
-| candidate | Median of the candidate's fresh-process block medians                                                  |
-| Δp50      | Signed percent change between those block-median summaries                                             |
-| Δp99      | Descriptive percent change in p99 from the pooled inner samples                                        |
-| p         | Mann-Whitney U p-value on block medians; at or below `alpha` = statistically significant               |
-| Δ CI      | Hodges-Lehmann shift estimate's confidence interval (level `1 − alpha`), from inverting the exact test |
+| Column    | Description                                                                                                            |
+| --------- | ---------------------------------------------------------------------------------------------------------------------- |
+| baseline  | Median of the baseline's fresh-process block medians                                                                   |
+| candidate | Median of the candidate's fresh-process block medians                                                                  |
+| Δp50      | Signed percent change between those two medians; descriptive and not used by the verdict gate                          |
+| Δp99      | Descriptive percent change in p99 from the pooled inner samples                                                        |
+| p         | Two-sided Mann-Whitney U p-value on block medians; at or below `alpha` passes the statistical-significance gate        |
+| Δ CI      | Nominal `1 − alpha` interval for the Hodges-Lehmann relative effect used by the verdict; not an interval around `Δp50` |
 
-Each row is prefixed with a verdict icon: green `▲` (faster), red `▼` (slower), or gray `■` (neutral). Below each row, two distribution sparklines sit under their respective columns — baseline (cyan) and candidate (magenta) — on a shared axis. This makes distribution shifts, bimodal behavior, and tail changes visible at a glance.
+Each row is prefixed with a verdict icon: green `▲` (faster), red `▼` (slower), or gray `■` (neutral). The verdict uses the Mann-Whitney p-value and the Hodges-Lehmann relative effect, not `Δp50`. Below each row, two distribution sparklines sit under their respective columns — baseline (cyan) and candidate (magenta) — on a shared axis. The sparklines use pooled inner samples and are descriptive only.
 
 Comparison is gated. Two runs must pass environment checks before results are shown.
 
@@ -223,12 +230,13 @@ Comparison is gated. Two runs must pass environment checks before results are sh
 
 - **Clock drift** — if either run's CPU frequency drifted > 5% during the run, a warning is shown. On Apple Silicon this is expected (no governor or turbo control); on other platforms it usually means turbo boost or thermal throttling is active.
 - **Clock speed mismatch** — if the two runs' median clock speeds differ by > 5%, a warning is shown. Absolute timings may not be directly comparable.
+- **Isolation mismatch** — if the runs used different per-bench isolation modes, a warning is shown because shared-process JIT and heap state may make their absolute timings incomparable.
 - **Block count mismatch** — unequal counts are supported, but the actual counts determine whether the test can reach the configured significance level.
 
-**Per-bench checks** (fail = that bench is skipped with a reason):
+**Per-benchmark eligibility and annotations:**
 
 - **Not missing** — the bench must exist in both runs. Benches present only in baseline or only in candidate are reported separately.
-- **Noisy benches are annotated, not skipped** — a bench whose between-block spread cannot resolve `minDelta` still gets judged (the exact test on block medians is already spread-aware), but its row carries a `⚠ ~±N%` resolution marker: a neutral there means "could not tell", not "no change".
+- **Limited-resolution benches are annotated, not skipped** — a bench whose approximate between-block resolution is coarser than `minDelta` still gets judged because the rank test already responds to spread. Its row carries a `⚠ ~±N%` marker; a neutral result there is inconclusive at the shown resolution, not evidence of no change.
 - **Block replication** — both sides need at least two fresh-process blocks, and their combined counts must permit an exact p-value at or below `alpha`. Legacy single-process results are descriptive only.
 
 ## Writing a bench
@@ -274,18 +282,26 @@ pnpm bench "@slow"        # runs only wildcard
 
 ## Statistical comparison strategy
 
-Saved runs measure each benchmark in fresh-process blocks, eight by default. The first process chooses a measurement plan, and later processes replay its batching and sample-count decisions. Blocks are interleaved across benchmarks so every benchmark spans the run. Inner timing samples remain useful for distributions and p99, but the independently replicated block medians are the units used for comparison verdicts.
+Saved runs measure each benchmark in fresh-process blocks, eight by default. The first block of each benchmark chooses a measurement plan within its share of the configured budget; later blocks replay its batching and sample-count decisions exactly. Blocks are interleaved across benchmarks so every benchmark spans the run. Inner timing samples remain useful for distributions and p99, but each block's median is treated as one independent experimental unit for comparison verdicts.
 
 A change is flagged only when both conditions are met:
 
-1. **p ≤ alpha** (Mann-Whitney U, default 0.05) — statistical significance across block medians. Comparisons with up to 50 blocks combined use an exact conditional permutation distribution, including tied medians. Larger samples use the tie-corrected normal approximation.
-2. **|Hodges-Lehmann Δ| ≥ minDelta** (default 0.05) — practical magnitude. The [Hodges-Lehmann estimator](https://en.wikipedia.org/wiki/Hodges%E2%80%93Lehmann_estimator) is the median of all pairwise candidate/baseline block-median ratios; its confidence interval (the `Δ CI` column) comes from inverting the exact test, so a significant result is one whose interval excludes zero.
+1. **p ≤ alpha** (two-sided Mann-Whitney U, default 0.05) — statistical significance across block medians. Comparisons with at most 50 blocks combined use the exact conditional permutation distribution of the observed ranks, including tied medians. Larger samples use a continuity- and tie-corrected normal approximation.
+2. **|Hodges-Lehmann Δ| ≥ minDelta** (default 0.05) — practical magnitude. The relative estimator is the median of all pairwise `candidate / baseline` block-median ratios, minus one. Positive values mean slower and negative values mean faster.
+
+Both gates must pass to report faster or slower; otherwise the result is neutral. The displayed `Δp50` is the percent change between the two median block medians, so it can differ slightly from the Hodges-Lehmann effect used by the verdict. The `Δ CI` column is a rank-based interval around the Hodges-Lehmann relative effect. Its endpoints use exact tie-free Mann-Whitney critical ranks at the nominal `1 − alpha` level; ties make the interval slightly conservative. The interval is uncertainty context, not a third verdict gate and not a confidence interval for `Δp50`.
 
 Effect-size gating (Cliff's d) was removed: on block medians it is a monotone transform of the same U statistic behind the p-value, so a separate threshold added confusion without adding information.
 
 A verdict must also survive the clock cross-check: when the two runs' median block clocks differ by more than 2%, the same block medians are re-judged in estimated CPU cycles (median × its block's clock probe), and a disagreement between the time and cycles verdicts skips the bench as clock-confounded rather than reporting a shift that may just be a frequency difference. When clocks are effectively equal the cross-check is inert — cycles would only re-scale time by probe jitter.
 
 The pooled inner-sample sparklines and p99 ratio are descriptive. They help expose distribution and tail changes but are not independently significance-tested.
+
+### Between-block spread and resolution
+
+Labs summarizes each run's block medians with a robust relative spread: `1.4826 × MAD / median`. It turns that spread into an approximate minimum detectable effect using `2.8 × spread × √(2 / blocks)`. The estimate is a normal-theory planning heuristic for 5% significance and 80% power with equal-sized groups, while actual verdicts use the rank test above. Treat it as an order-of-magnitude resolution diagnostic, not a guaranteed or hard detection limit.
+
+During comparison, Labs calculates the resolution separately for baseline and candidate and displays the worse of the two. When it exceeds `minDelta`, the row is annotated as limited-resolution, but the verdict is still evaluated. Large, well-separated effects can therefore receive a verdict despite inconsistent fresh runs; a neutral result at limited resolution means that the data could not establish a change at that scale.
 
 Each p-value applies to one benchmark. Labs does not currently adjust `alpha` across a suite, and separately saved baseline and candidate sessions can still differ in unmeasured machine state. Treat suite-wide or causal conclusions accordingly.
 
@@ -303,38 +319,38 @@ export default defineConfig({
 })
 ```
 
-| Option       | Default                                     | Description                                                                                                                                                                                                                                         |
-| ------------ | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `benchDir`   | (required)                                  | Directory to search, relative to config file                                                                                                                                                                                                        |
-| `benchMatch` | `**/*.bench.ts`                             | Glob pattern for discovery                                                                                                                                                                                                                          |
-| `nodeFlags`  | `['--allow-natives-syntax', '--expose-gc']` | Node flags per worker process                                                                                                                                                                                                                       |
-| `resultsDir` | `.labs`                                     | Directory for saved results, relative to config                                                                                                                                                                                                     |
-| `adaptive`   | `true`                                      | Adaptive sampling mode: `true` uses default CI threshold, `false` disables, number sets CI threshold (e.g. `0.01`)                                                                                                                                  |
-| `maxCpuTime` | `5`                                         | Max CPU budget in seconds for adaptive sampling; benches that don't converge or reach `minSamples` are `noisy`                                                                                                                                      |
-| `minCpuTime` | `0.642`                                     | Minimum CPU time budget per benchmark in seconds; set to raise/lower runtime budget                                                                                                                                                                 |
-| `minSamples` | `20`                                        | Minimum sample count per benchmark; set to increase/decrease sample floor                                                                                                                                                                           |
-| `maxSamples` | `1e9`                                       | Maximum sample cap per benchmark to prevent pathological long runs                                                                                                                                                                                  |
-| `alpha`      | `0.05`                                      | Mann-Whitney U significance level                                                                                                                                                                                                                   |
-| `minDelta`   | `0.05`                                      | Minimum absolute Hodges-Lehmann delta to flag a verdict; blocked runs whose spread cannot resolve it are reported as noisy                                                                                                                          |
-| `isolate`    | `true`                                      | Run each bench in its own fresh worker process so benches can't contaminate each other's JIT/heap state (order-dependent results); `false` shares one process per file and disables blocked sampling, so such saves cannot receive compare verdicts |
-| `blocks`     | `8`                                         | Fresh-process blocks per benchmark for saved runs; `bench run` uses one unless overridden with `--blocks`                                                                                                                                           |
+| Option       | Default                                     | Description                                                                                                                                                                                                                                             |
+| ------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `benchDir`   | (required)                                  | Directory to search, relative to config file                                                                                                                                                                                                            |
+| `benchMatch` | `**/*.bench.ts`                             | Glob pattern for discovery                                                                                                                                                                                                                              |
+| `nodeFlags`  | `['--allow-natives-syntax', '--expose-gc']` | Node flags per worker process                                                                                                                                                                                                                           |
+| `resultsDir` | `.labs`                                     | Directory for saved results, relative to config                                                                                                                                                                                                         |
+| `adaptive`   | `true`                                      | Adaptive sampling mode: `true` uses the default 2.5% relative uncertainty target, `false` uses fixed stopping, and a number sets a custom target                                                                                                        |
+| `maxCpuTime` | `5`                                         | Maximum sampling-time budget in seconds; a multi-block pilot receives a per-block share, while later blocks replay its fixed sample count                                                                                                               |
+| `minCpuTime` | `0.642`                                     | Minimum CPU time budget per benchmark in seconds; set to raise/lower runtime budget                                                                                                                                                                     |
+| `minSamples` | `20`                                        | Minimum sample count per benchmark; set to increase/decrease sample floor                                                                                                                                                                               |
+| `maxSamples` | `1e9`                                       | Maximum sample cap per benchmark to prevent pathological long runs                                                                                                                                                                                      |
+| `alpha`      | `0.05`                                      | Mann-Whitney U significance level                                                                                                                                                                                                                       |
+| `minDelta`   | `0.05`                                      | Minimum absolute Hodges-Lehmann relative effect for a verdict; rows whose approximate resolution exceeds it are annotated as limited-resolution                                                                                                         |
+| `isolate`    | `true`                                      | Run each bench in its own fresh worker process so benches can't contaminate each other's JIT/heap state (order-dependent results); `false` shares one process per file and disables multi-block sampling, so such saves cannot receive compare verdicts |
+| `blocks`     | `8`                                         | Fresh-process blocks per benchmark for saved runs; `bench run` uses one unless overridden with `--blocks`                                                                                                                                               |
 
 Sampling behavior:
 
-- `adaptive: false`: fixed stopping (`samples >= minSamples` and `cpu_time >= minCpuTime`) with `maxSamples` as cap.
-- `adaptive: true`: adaptive CI stopping with default threshold (`2.5%`), but never before `minSamples` and `minCpuTime`.
-- `adaptive: <number>`: same adaptive behavior with a custom CI threshold (`0.01` is stricter than `0.025`).
-- In adaptive mode, `maxCpuTime` is a hard budget. Benchmarks that don't converge or don't reach `minSamples` are marked `noisy`.
-- In blocked mode, the pilot gets a fraction of `maxCpuTime`, and later blocks replay its measurement plan. Noisiness is derived from between-block spread at report/compare time against the current `minDelta` — it is never baked into the save, so retuning `minDelta` re-evaluates existing results.
+- `adaptive: false`: fixed stopping (`samples >= minSamples` and measured time `>= minCpuTime`) with `maxSamples` as a cap.
+- `adaptive: true`: adaptive stopping at the default 2.5% relative uncertainty target, but never before `minSamples` and `minCpuTime`.
+- `adaptive: <number>`: the same adaptive behavior with a custom target (`0.01` is stricter than `0.025`).
+- In a single-block adaptive run, `maxCpuTime` is the bailout budget. Hitting it before the uncertainty target or `minSamples` reports the samples as unstable.
+- In multi-block mode, the pilot receives `maxCpuTime / blocks` and later blocks replay its plan without adaptive stopping. The saved result does not retain the pilot's convergence flag. Its limited-resolution annotation is instead derived from between-block spread against the current `minDelta`, so changing `minDelta` re-evaluates existing results.
 
 > [!NOTE]
 > **More info: adaptive statistics**
 >
-> Labs uses online variance in log-space (Welford update) to handle long-tailed VM timing samples. This means convergence is based on multiplicative error (relative confidence), which is usually more stable for benchmark timing data than linear-space variance.
+> Labs uses a Welford update in log-space to track the standard error of the mean log timing. This makes the stopping target relative and multiplicative, which is usually more appropriate for timing data than an absolute linear-space target.
 >
 > Stopping in adaptive mode is:
 >
 > - Floor: wait until both `minSamples` and `minCpuTime` are reached
-> - Converged: stop once the relative CI target is met (`adaptive: true` => `2.5%`, `adaptive: 0.01` => `1%`)
-> - Bailout: if convergence or `minSamples` is not reached before `maxCpuTime`, mark as `noisy`
+> - Converged: stop once the log-space standard error reaches the relative target (`adaptive: true` => `2.5%`, `adaptive: 0.01` => `1%`)
+> - Bailout: if the target or `minSamples` is not reached before `maxCpuTime`, report the samples as unstable
 > - Safety cap: `maxSamples` still limits pathological runs

--- a/README.md
+++ b/README.md
@@ -83,12 +83,15 @@ benchmark                   avg (min … max) p75 / p99    (min … top 1%)
 
 #### Guarantees
 
-Labs promises to give results you can trust. To do this we make a number of guarantees when running benches.
+Labs promises to give results you can trust. To do this a number of guarantees are made when running benches.
 
-- Each bench runs in its own isolated worker process, preventing benches in the same file from contaminating each other's JIT state, heap layout, or GC history. Reordering benches can otherwise skew results by 2× or more. Opt out with `isolate: false` in the config or `--no-isolate` in the CLI.
-- CPU clock speed is measured before and after the run. If it drifts, Labs flags the result so it doesn't pollute comparisons.
-- Adaptive sampling continues until the confidence interval converges, or marks the bench `noisy` if it can't. This usually means the bench contains some random element and is not deterministic.
-- Each sample starts with a garbage collection (GC) reset so previous samples don't affect it.
+- Each bench runs in its own isolated worker process, preventing benches in the same file from contaminating each other's JIT state, heap layout, or GC history. Reordering benches can otherwise skew results by 2x or more. Opt out with `isolate: false` in the config or `--no-isolate` in the CLI.
+- GC influence is mitigated. Each sample starts with a garbage collection (GC) reset so previous samples don't affect it.
+- Benches are run in blocks that are interleaved: `A₁ B₁ C₁ → A₂ B₂ C₂ → … → A₈ B₈ C₈`. This reduces bias from gradual changes such as CPU throttling or even boosting.
+- Timing overhead is controlled. If a sample's measurement time is so fast that the overhead of the timing itself would bias the results then it is run in a batch.
+- Detect dead code elimination (DCE). If the samples measure the same as an empty function call then we detect DCE and report it. This can be mitigated by returning a result inside the yield.
+- Detect if a bench is unstable. Samples are taken for a bench run until it settles into stastical significance. If this fails, a warning is given. This likely means the bench is non-determinstic.
+- Machine stability is measured. When the median timings between the interleaved runs is unstable, a warning is also given. This usually means the machine is too unstable to give useful measurements.
 
 ### Compare
 
@@ -199,13 +202,13 @@ pnpm bench compare -l                 # shorthand for --last
 
 Outputs a colored table for each eligible benchmark:
 
-| Column    | Description                                                                                          |
-| --------- | ---------------------------------------------------------------------------------------------------- |
-| baseline  | Median of the baseline's fresh-process block medians                                                 |
-| candidate | Median of the candidate's fresh-process block medians                                                |
-| Δp50      | Signed percent change between those block-median summaries                                           |
-| Δp99      | Descriptive percent change in p99 from the pooled inner samples                                      |
-| p         | Mann-Whitney U p-value on block medians; at or below `alpha` = statistically significant             |
+| Column    | Description                                                                                            |
+| --------- | ------------------------------------------------------------------------------------------------------ |
+| baseline  | Median of the baseline's fresh-process block medians                                                   |
+| candidate | Median of the candidate's fresh-process block medians                                                  |
+| Δp50      | Signed percent change between those block-median summaries                                             |
+| Δp99      | Descriptive percent change in p99 from the pooled inner samples                                        |
+| p         | Mann-Whitney U p-value on block medians; at or below `alpha` = statistically significant               |
 | Δ CI      | Hodges-Lehmann shift estimate's confidence interval (level `1 − alpha`), from inverting the exact test |
 
 Each row is prefixed with a verdict icon: green `▲` (faster), red `▼` (slower), or gray `■` (neutral). Below each row, two distribution sparklines sit under their respective columns — baseline (cyan) and candidate (magenta) — on a shared axis. This makes distribution shifts, bimodal behavior, and tail changes visible at a glance.
@@ -300,21 +303,21 @@ export default defineConfig({
 })
 ```
 
-| Option       | Default                                     | Description                                                                                                                                                            |
-| ------------ | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `benchDir`   | (required)                                  | Directory to search, relative to config file                                                                                                                           |
-| `benchMatch` | `**/*.bench.ts`                             | Glob pattern for discovery                                                                                                                                             |
-| `nodeFlags`  | `['--allow-natives-syntax', '--expose-gc']` | Node flags per worker process                                                                                                                                          |
-| `resultsDir` | `.labs`                                     | Directory for saved results, relative to config                                                                                                                        |
-| `adaptive`   | `true`                                      | Adaptive sampling mode: `true` uses default CI threshold, `false` disables, number sets CI threshold (e.g. `0.01`)                                                     |
-| `maxCpuTime` | `5`                                         | Max CPU budget in seconds for adaptive sampling; benches that don't converge or reach `minSamples` are `noisy`                                                         |
-| `minCpuTime` | `0.642`                                     | Minimum CPU time budget per benchmark in seconds; set to raise/lower runtime budget                                                                                    |
-| `minSamples` | `20`                                        | Minimum sample count per benchmark; set to increase/decrease sample floor                                                                                              |
-| `maxSamples` | `1e9`                                       | Maximum sample cap per benchmark to prevent pathological long runs                                                                                                     |
-| `alpha`      | `0.05`                                      | Mann-Whitney U significance level                                                                                                                                      |
-| `minDelta`   | `0.05`                                      | Minimum absolute Hodges-Lehmann delta to flag a verdict; blocked runs whose spread cannot resolve it are reported as noisy                                              |
+| Option       | Default                                     | Description                                                                                                                                                                                                                                         |
+| ------------ | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `benchDir`   | (required)                                  | Directory to search, relative to config file                                                                                                                                                                                                        |
+| `benchMatch` | `**/*.bench.ts`                             | Glob pattern for discovery                                                                                                                                                                                                                          |
+| `nodeFlags`  | `['--allow-natives-syntax', '--expose-gc']` | Node flags per worker process                                                                                                                                                                                                                       |
+| `resultsDir` | `.labs`                                     | Directory for saved results, relative to config                                                                                                                                                                                                     |
+| `adaptive`   | `true`                                      | Adaptive sampling mode: `true` uses default CI threshold, `false` disables, number sets CI threshold (e.g. `0.01`)                                                                                                                                  |
+| `maxCpuTime` | `5`                                         | Max CPU budget in seconds for adaptive sampling; benches that don't converge or reach `minSamples` are `noisy`                                                                                                                                      |
+| `minCpuTime` | `0.642`                                     | Minimum CPU time budget per benchmark in seconds; set to raise/lower runtime budget                                                                                                                                                                 |
+| `minSamples` | `20`                                        | Minimum sample count per benchmark; set to increase/decrease sample floor                                                                                                                                                                           |
+| `maxSamples` | `1e9`                                       | Maximum sample cap per benchmark to prevent pathological long runs                                                                                                                                                                                  |
+| `alpha`      | `0.05`                                      | Mann-Whitney U significance level                                                                                                                                                                                                                   |
+| `minDelta`   | `0.05`                                      | Minimum absolute Hodges-Lehmann delta to flag a verdict; blocked runs whose spread cannot resolve it are reported as noisy                                                                                                                          |
 | `isolate`    | `true`                                      | Run each bench in its own fresh worker process so benches can't contaminate each other's JIT/heap state (order-dependent results); `false` shares one process per file and disables blocked sampling, so such saves cannot receive compare verdicts |
-| `blocks`     | `8`                                         | Fresh-process blocks per benchmark for saved runs; `bench run` uses one unless overridden with `--blocks`                                                              |
+| `blocks`     | `8`                                         | Fresh-process blocks per benchmark for saved runs; `bench run` uses one unless overridden with `--blocks`                                                                                                                                           |
 
 Sampling behavior:
 

--- a/README.md
+++ b/README.md
@@ -199,13 +199,14 @@ pnpm bench compare -l                 # shorthand for --last
 
 Outputs a colored table for each eligible benchmark:
 
-| Column    | Description                                                                              |
-| --------- | ---------------------------------------------------------------------------------------- |
-| baseline  | Median of the baseline's fresh-process block medians                                     |
-| candidate | Median of the candidate's fresh-process block medians                                    |
-| Δp50      | Signed percent change between those block-median summaries                               |
-| Δp99      | Descriptive percent change in p99 from the pooled inner samples                          |
-| p         | Mann-Whitney U p-value on block medians; at or below `alpha` = statistically significant |
+| Column    | Description                                                                                          |
+| --------- | ---------------------------------------------------------------------------------------------------- |
+| baseline  | Median of the baseline's fresh-process block medians                                                 |
+| candidate | Median of the candidate's fresh-process block medians                                                |
+| Δp50      | Signed percent change between those block-median summaries                                           |
+| Δp99      | Descriptive percent change in p99 from the pooled inner samples                                      |
+| p         | Mann-Whitney U p-value on block medians; at or below `alpha` = statistically significant             |
+| Δ CI      | Hodges-Lehmann shift estimate's confidence interval (level `1 − alpha`), from inverting the exact test |
 
 Each row is prefixed with a verdict icon: green `▲` (faster), red `▼` (slower), or gray `■` (neutral). Below each row, two distribution sparklines sit under their respective columns — baseline (cyan) and candidate (magenta) — on a shared axis. This makes distribution shifts, bimodal behavior, and tail changes visible at a glance.
 
@@ -224,7 +225,7 @@ Comparison is gated. Two runs must pass environment checks before results are sh
 **Per-bench checks** (fail = that bench is skipped with a reason):
 
 - **Not missing** — the bench must exist in both runs. Benches present only in baseline or only in candidate are reported separately.
-- **Not noisy** — neither run's estimated between-run resolution may exceed `minDelta`.
+- **Noisy benches are annotated, not skipped** — a bench whose between-block spread cannot resolve `minDelta` still gets judged (the exact test on block medians is already spread-aware), but its row carries a `⚠ ~±N%` resolution marker: a neutral there means "could not tell", not "no change".
 - **Block replication** — both sides need at least two fresh-process blocks, and their combined counts must permit an exact p-value at or below `alpha`. Legacy single-process results are descriptive only.
 
 ## Writing a bench
@@ -272,11 +273,14 @@ pnpm bench "@slow"        # runs only wildcard
 
 Saved runs measure each benchmark in fresh-process blocks, eight by default. The first process chooses a measurement plan, and later processes replay its batching and sample-count decisions. Blocks are interleaved across benchmarks so every benchmark spans the run. Inner timing samples remain useful for distributions and p99, but the independently replicated block medians are the units used for comparison verdicts.
 
-A change is flagged only when all three conditions are met:
+A change is flagged only when both conditions are met:
 
 1. **p ≤ alpha** (Mann-Whitney U, default 0.05) — statistical significance across block medians. Comparisons with up to 50 blocks combined use an exact conditional permutation distribution, including tied medians. Larger samples use the tie-corrected normal approximation.
-2. **|Δp50| ≥ ±Δ** (noise-adjusted, floor `minDelta`) — practical magnitude. The threshold is `max(minDelta, 3 × relative MAD)`, using `MAD/median` from the noisier set of block medians. The `±Δ` column shows the effective threshold.
-3. **|cliff's d| ≥ minEffect** (default 0.474) — effect size across block medians. [Cliff's delta](https://en.wikipedia.org/wiki/Effect_size#Cliff's_delta) measures distribution separation from -1 to +1.
+2. **|Hodges-Lehmann Δ| ≥ minDelta** (default 0.05) — practical magnitude. The [Hodges-Lehmann estimator](https://en.wikipedia.org/wiki/Hodges%E2%80%93Lehmann_estimator) is the median of all pairwise candidate/baseline block-median ratios; its confidence interval (the `Δ CI` column) comes from inverting the exact test, so a significant result is one whose interval excludes zero.
+
+Effect-size gating (Cliff's d) was removed: on block medians it is a monotone transform of the same U statistic behind the p-value, so a separate threshold added confusion without adding information.
+
+A verdict must also survive the clock cross-check: when the two runs' median block clocks differ by more than 2%, the same block medians are re-judged in estimated CPU cycles (median × its block's clock probe), and a disagreement between the time and cycles verdicts skips the bench as clock-confounded rather than reporting a shift that may just be a frequency difference. When clocks are effectively equal the cross-check is inert — cycles would only re-scale time by probe jitter.
 
 The pooled inner-sample sparklines and p99 ratio are descriptive. They help expose distribution and tail changes but are not independently significance-tested.
 
@@ -308,9 +312,8 @@ export default defineConfig({
 | `minSamples` | `20`                                        | Minimum sample count per benchmark; set to increase/decrease sample floor                                                                                              |
 | `maxSamples` | `1e9`                                       | Maximum sample cap per benchmark to prevent pathological long runs                                                                                                     |
 | `alpha`      | `0.05`                                      | Mann-Whitney U significance level                                                                                                                                      |
-| `minDelta`   | `0.05`                                      | Floor for the noise-adjusted ±Δ threshold; the effective threshold per bench is `max(minDelta, 3 × relative MAD)`                                                      |
-| `minEffect`  | `0.474`                                     | Minimum absolute Cliff's d to flag a verdict; filters noise on high-variance benches where distributions overlap                                                       |
-| `isolate`    | `true`                                      | Run each bench in its own fresh worker process so benches can't contaminate each other's JIT/heap state (order-dependent results); `false` shares one process per file |
+| `minDelta`   | `0.05`                                      | Minimum absolute Hodges-Lehmann delta to flag a verdict; blocked runs whose spread cannot resolve it are reported as noisy                                              |
+| `isolate`    | `true`                                      | Run each bench in its own fresh worker process so benches can't contaminate each other's JIT/heap state (order-dependent results); `false` shares one process per file and disables blocked sampling, so such saves cannot receive compare verdicts |
 | `blocks`     | `8`                                         | Fresh-process blocks per benchmark for saved runs; `bench run` uses one unless overridden with `--blocks`                                                              |
 
 Sampling behavior:
@@ -319,7 +322,7 @@ Sampling behavior:
 - `adaptive: true`: adaptive CI stopping with default threshold (`2.5%`), but never before `minSamples` and `minCpuTime`.
 - `adaptive: <number>`: same adaptive behavior with a custom CI threshold (`0.01` is stricter than `0.025`).
 - In adaptive mode, `maxCpuTime` is a hard budget. Benchmarks that don't converge or don't reach `minSamples` are marked `noisy`.
-- In blocked mode, the pilot gets a fraction of `maxCpuTime`, and later blocks replay its measurement plan. Between-block spread determines the saved `noisy` flag.
+- In blocked mode, the pilot gets a fraction of `maxCpuTime`, and later blocks replay its measurement plan. Noisiness is derived from between-block spread at report/compare time against the current `minDelta` — it is never baked into the save, so retuning `minDelta` re-evaluates existing results.
 
 > [!NOTE]
 > **More info: adaptive statistics**

--- a/README.md
+++ b/README.md
@@ -199,13 +199,13 @@ pnpm bench compare -l                 # shorthand for --last
 
 Outputs a colored table for each eligible benchmark:
 
-| Column    | Description                                                                                 |
-| --------- | ------------------------------------------------------------------------------------------- |
-| baseline  | Baseline p50 (median) time                                                                  |
-| candidate | Candidate p50 (median) time                                                                 |
-| Δp50      | Signed percent change in p50 — color-coded green (faster), red (slower), or dim (neutral)   |
-| Δp99      | Signed percent change in p99 — when this diverges from Δp50, the distribution shape changed |
-| p         | Mann-Whitney U p-value — below `alpha` = statistically significant                          |
+| Column    | Description                                                                              |
+| --------- | ---------------------------------------------------------------------------------------- |
+| baseline  | Median of the baseline's fresh-process block medians                                     |
+| candidate | Median of the candidate's fresh-process block medians                                    |
+| Δp50      | Signed percent change between those block-median summaries                               |
+| Δp99      | Descriptive percent change in p99 from the pooled inner samples                          |
+| p         | Mann-Whitney U p-value on block medians; at or below `alpha` = statistically significant |
 
 Each row is prefixed with a verdict icon: green `▲` (faster), red `▼` (slower), or gray `■` (neutral). Below each row, two distribution sparklines sit under their respective columns — baseline (cyan) and candidate (magenta) — on a shared axis. This makes distribution shifts, bimodal behavior, and tail changes visible at a glance.
 
@@ -219,12 +219,13 @@ Comparison is gated. Two runs must pass environment checks before results are sh
 
 - **Clock drift** — if either run's CPU frequency drifted > 5% during the run, a warning is shown. On Apple Silicon this is expected (no governor or turbo control); on other platforms it usually means turbo boost or thermal throttling is active.
 - **Clock speed mismatch** — if the two runs' median clock speeds differ by > 5%, a warning is shown. Absolute timings may not be directly comparable.
+- **Block count mismatch** — unequal counts are supported, but the actual counts determine whether the test can reach the configured significance level.
 
 **Per-bench checks** (fail = that bench is skipped with a reason):
 
 - **Not missing** — the bench must exist in both runs. Benches present only in baseline or only in candidate are reported separately.
-- **Not noisy** — neither run's samples can be flagged `noisy` (adaptive sampling hit `maxCpuTime` before converging). Noisy data is not reliable enough to compare.
-- **Minimum samples** — both runs must have ≥ 14 samples after outlier trimming. The MW-U normal approximation is unreliable below this threshold.
+- **Not noisy** — neither run's estimated between-run resolution may exceed `minDelta`.
+- **Block replication** — both sides need at least two fresh-process blocks, and their combined counts must permit an exact p-value at or below `alpha`. Legacy single-process results are descriptive only.
 
 ## Writing a bench
 
@@ -269,15 +270,17 @@ pnpm bench "@slow"        # runs only wildcard
 
 ## Statistical comparison strategy
 
-Labs is single-run only. Each benchmark comparison uses mitata's collected sample arrays for the baseline and candidate.
+Saved runs measure each benchmark in fresh-process blocks, eight by default. The first process chooses a measurement plan, and later processes replay its batching and sample-count decisions. Blocks are interleaved across benchmarks so every benchmark spans the run. Inner timing samples remain useful for distributions and p99, but the independently replicated block medians are the units used for comparison verdicts.
 
 A change is flagged only when all three conditions are met:
 
-1. **p ≤ alpha** (Mann-Whitney U, default 0.05) — statistical significance. The Mann-Whitney U test is a non-parametric, rank-based test that determines whether values from one group consistently rank higher than the other. It is robust to non-normal distributions and GC-induced outliers.
-2. **|Δp50| ≥ ±Δ** (noise-adjusted, floor `minDelta`) — practical magnitude. The threshold adapts per benchmark based on observed noise: `±Δ = max(minDelta, 3 × relative MAD)`, where relative MAD is `MAD/median` of the noisier distribution. On stable systems (pinned CPU, low variance) this resolves small changes (1–2%). On noisier systems (Apple Silicon, untuned environments) the threshold rises automatically (4–8%), preventing false positives from environmental variance. The `±Δ` column in the compare table shows each bench's effective threshold.
-3. **|cliff's d| ≥ minEffect** (default 0.474) — effect size. [Cliff's delta](https://en.wikipedia.org/wiki/Effect_size#Cliff's_delta) measures how separated two distributions are (range [-1, +1]). High-variance benchmarks can show large median shifts while the actual sample distributions overlap heavily — a sign of JIT/scheduling noise rather than a real code change. The default threshold of 0.474 corresponds to the "medium" effect size boundary (Romano et al. 2006), meaning at least ~74% of pairwise sample comparisons must favor one direction.
+1. **p ≤ alpha** (Mann-Whitney U, default 0.05) — statistical significance across block medians. Comparisons with up to 50 blocks combined use an exact conditional permutation distribution, including tied medians. Larger samples use the tie-corrected normal approximation.
+2. **|Δp50| ≥ ±Δ** (noise-adjusted, floor `minDelta`) — practical magnitude. The threshold is `max(minDelta, 3 × relative MAD)`, using `MAD/median` from the noisier set of block medians. The `±Δ` column shows the effective threshold.
+3. **|cliff's d| ≥ minEffect** (default 0.474) — effect size across block medians. [Cliff's delta](https://en.wikipedia.org/wiki/Effect_size#Cliff's_delta) measures distribution separation from -1 to +1.
 
-The p99 ratio provides a variance/stability signal. When it diverges from the p50 ratio, the distribution shape changed between runs (e.g., tails got worse even if the median improved).
+The pooled inner-sample sparklines and p99 ratio are descriptive. They help expose distribution and tail changes but are not independently significance-tested.
+
+Each p-value applies to one benchmark. Labs does not currently adjust `alpha` across a suite, and separately saved baseline and candidate sessions can still differ in unmeasured machine state. Treat suite-wide or causal conclusions accordingly.
 
 ## Config
 
@@ -293,21 +296,22 @@ export default defineConfig({
 })
 ```
 
-| Option | Default | Description |
-| ------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------- |
-| `benchDir` | (required) | Directory to search, relative to config file |
-| `benchMatch` | `**/*.bench.ts` | Glob pattern for discovery |
-| `nodeFlags` | `['--allow-natives-syntax', '--expose-gc']` | Node flags per worker process |
-| `resultsDir` | `.labs` | Directory for saved results, relative to config |
-| `adaptive` | `true` | Adaptive sampling mode: `true` uses default CI threshold, `false` disables, number sets CI threshold (e.g. `0.01`) |
-| `maxCpuTime` | `5` | Max CPU budget in seconds for adaptive sampling; benches that don't converge or reach `minSamples` are `noisy` |
-| `minCpuTime` | `0.642` | Minimum CPU time budget per benchmark in seconds; set to raise/lower runtime budget |
-| `minSamples` | `20` | Minimum sample count per benchmark; set to increase/decrease sample floor |
-| `maxSamples` | `1e9` | Maximum sample cap per benchmark to prevent pathological long runs |
-| `alpha` | `0.05` | Mann-Whitney U significance level |
-| `minDelta` | `0.05` | Floor for the noise-adjusted ±Δ threshold; the effective threshold per bench is `max(minDelta, 3 × relative MAD)` |
-| `minEffect` | `0.474` | Minimum | Cliff's d | to flag a verdict; filters noise on high-variance benches where distributions overlap |
-| `isolate` | `true` | Run each bench in its own fresh worker process so benches can't contaminate each other's JIT/heap state (order-dependent results); `false` shares one process per file |
+| Option       | Default                                     | Description                                                                                                                                                            |
+| ------------ | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `benchDir`   | (required)                                  | Directory to search, relative to config file                                                                                                                           |
+| `benchMatch` | `**/*.bench.ts`                             | Glob pattern for discovery                                                                                                                                             |
+| `nodeFlags`  | `['--allow-natives-syntax', '--expose-gc']` | Node flags per worker process                                                                                                                                          |
+| `resultsDir` | `.labs`                                     | Directory for saved results, relative to config                                                                                                                        |
+| `adaptive`   | `true`                                      | Adaptive sampling mode: `true` uses default CI threshold, `false` disables, number sets CI threshold (e.g. `0.01`)                                                     |
+| `maxCpuTime` | `5`                                         | Max CPU budget in seconds for adaptive sampling; benches that don't converge or reach `minSamples` are `noisy`                                                         |
+| `minCpuTime` | `0.642`                                     | Minimum CPU time budget per benchmark in seconds; set to raise/lower runtime budget                                                                                    |
+| `minSamples` | `20`                                        | Minimum sample count per benchmark; set to increase/decrease sample floor                                                                                              |
+| `maxSamples` | `1e9`                                       | Maximum sample cap per benchmark to prevent pathological long runs                                                                                                     |
+| `alpha`      | `0.05`                                      | Mann-Whitney U significance level                                                                                                                                      |
+| `minDelta`   | `0.05`                                      | Floor for the noise-adjusted ±Δ threshold; the effective threshold per bench is `max(minDelta, 3 × relative MAD)`                                                      |
+| `minEffect`  | `0.474`                                     | Minimum absolute Cliff's d to flag a verdict; filters noise on high-variance benches where distributions overlap                                                       |
+| `isolate`    | `true`                                      | Run each bench in its own fresh worker process so benches can't contaminate each other's JIT/heap state (order-dependent results); `false` shares one process per file |
+| `blocks`     | `8`                                         | Fresh-process blocks per benchmark for saved runs; `bench run` uses one unless overridden with `--blocks`                                                              |
 
 Sampling behavior:
 
@@ -315,6 +319,7 @@ Sampling behavior:
 - `adaptive: true`: adaptive CI stopping with default threshold (`2.5%`), but never before `minSamples` and `minCpuTime`.
 - `adaptive: <number>`: same adaptive behavior with a custom CI threshold (`0.01` is stricter than `0.025`).
 - In adaptive mode, `maxCpuTime` is a hard budget. Benchmarks that don't converge or don't reach `minSamples` are marked `noisy`.
+- In blocked mode, the pilot gets a fraction of `maxCpuTime`, and later blocks replay its measurement plan. Between-block spread determines the saved `noisy` flag.
 
 > [!NOTE]
 > **More info: adaptive statistics**

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "tsdown --config .config/build.config.ts",
     "prepack": "tsdown --config .config/build.config.ts",
     "release": "pnpm run build && pnpm publish",
-    "test": "vitest",
+    "test": "vitest -c .config/vitest.config.ts",
     "lint": "oxlint -c .config/oxlint.json",
     "format": "prettier --config .config/prettier.json --ignore-path .config/prettierignore --write .",
     "typecheck": "tsc --build --noEmit",

--- a/src/bench/lib/measure.ts
+++ b/src/bench/lib/measure.ts
@@ -118,6 +118,8 @@ export async function benchFn(fn: (...args: any[]) => any, opts: any = {}): Prom
     }
   }
 
+  if (opts.batch !== undefined) batch = !!opts.batch;
+
   if (opts.manual) {
     batch = false;
     opts.concurrency = 1;
@@ -348,6 +350,7 @@ export async function benchFn(fn: (...args: any[]) => any, opts: any = {}): Prom
       p999: samples[(.999 * (samples.length - 1)) | 0],
       avg: samples.reduce((a, v) => a + v, 0) / samples.length,
       ticks: samples.length ${!batch ? '' : `* ${opts.batch_samples}`},
+      plan: { batch: ${batch}, batch_samples: ${opts.batch_samples}, batch_unroll: ${opts.batch_unroll}, samples: _ },
       ${!opts.heap ? '' : 'heap: { ...heap, avg: heap.total / heap._ },'}
       ${!(opts.gc && opts.sample_gc && !opts.gc.fallback) ? '' : 'gc: { ...gc, avg: gc.total / _ },'}
       ${!opts.$counters ? '' : `...(!_hc ? {} : { counters: $counters.translate(${!batch ? 1 : opts.batch_samples}, _) }),`}
@@ -421,6 +424,8 @@ export async function benchIter(iter: (...args: any[]) => any, opts: any = {}): 
         }
       }
     }
+
+    if (opts.batch !== undefined) batch = !!opts.batch;
 
     const loop: Generator = new GeneratorFunction(
       '$gc',
@@ -499,11 +504,18 @@ export async function benchIter(iter: (...args: any[]) => any, opts: any = {}): 
     throw new TypeError(`expected at least ${opts.min_samples} samples from iterator`);
 
   samples.sort((a, b) => a - b);
+  const rawCount = samples.length;
   if (samples.length > opts.samples_threshold) samples = samples.slice(2, -2);
 
   return {
     samples,
     kind: 'iter' as const,
+    plan: {
+      batch: !!_.batch,
+      batch_samples: opts.batch_samples,
+      batch_unroll: opts.batch_unroll,
+      samples: rawCount,
+    },
     debug: _.debug,
     min: samples[0],
     max: samples[samples.length - 1],

--- a/src/bench/lib/measure.ts
+++ b/src/bench/lib/measure.ts
@@ -2,6 +2,13 @@ import type { MeasureOptions, Stats } from '../types.ts';
 import { AsyncFunction, do_not_optimize, GeneratorFunction, kind, now } from './runtime.ts';
 import { defaults } from './constants.ts';
 
+/** Adds the deprecated public field at the measurement API boundary. */
+function withLegacySampleStabilityAlias<T extends { samplesUnstable?: boolean }>(
+  stats: T
+): T & { noisy?: boolean } {
+  return stats.samplesUnstable === undefined ? stats : { ...stats, noisy: stats.samplesUnstable };
+}
+
 /**
  * Measure the performance of `f` by dispatching to the appropriate benchmark
  * engine ({@link benchFn}, {@link benchIter}, or {@link benchGenerator})
@@ -175,7 +182,7 @@ export async function benchFn(fn: (...args: any[]) => any, opts: any = {}): Prom
 
     let _ = 0; let t = 0;
     let samples = new Array(2 ** 20);
-    ${!opts.target_rel_ci ? '' : 'let _lm = 0; let _lm2 = 0; let _noisy = false;'}
+    ${!opts.target_rel_ci ? '' : 'let _lm = 0; let _lm2 = 0; let _samples_unstable = false;'}
     ${!opts.heap ? '' : 'const heap = { _: 0, total: 0, min: Infinity, max: -Infinity };'}
     ${!(opts.gc && opts.sample_gc && !opts.gc.fallback) ? '' : 'const gc = { total: 0, min: Infinity, max: -Infinity };'}
 
@@ -330,7 +337,7 @@ export async function benchFn(fn: (...args: any[]) => any, opts: any = {}): Prom
         _lm2 += _ld * (_lx - _lm);
         if (_ + 1 >= ${opts.min_samples} && t >= ${opts.min_cpu_time} && _lm2 / (_ * (_ + 1)) <= ${Math.log(1 + opts.target_rel_ci) ** 2}) { _++; break; }
       }
-      if (t >= ${opts.max_cpu_time}) { _noisy = true; _++; break; }
+      if (t >= ${opts.max_cpu_time}) { _samples_unstable = true; _++; break; }
       `
       }
     }
@@ -354,14 +361,14 @@ export async function benchFn(fn: (...args: any[]) => any, opts: any = {}): Prom
       ${!opts.heap ? '' : 'heap: { ...heap, avg: heap.total / heap._ },'}
       ${!(opts.gc && opts.sample_gc && !opts.gc.fallback) ? '' : 'gc: { ...gc, avg: gc.total / _ },'}
       ${!opts.$counters ? '' : `...(!_hc ? {} : { counters: $counters.translate(${!batch ? 1 : opts.batch_samples}, _) }),`}
-      ${!opts.target_rel_ci ? '' : 'noisy: _noisy,'}
+      ${!opts.target_rel_ci ? '' : 'samplesUnstable: _samples_unstable,'}
     };
 
     ${!opts.$counters ? '' : 'if (_hc) try { $counters.deinit(); } catch {};'}
   `
   );
 
-  return {
+  return withLegacySampleStabilityAlias({
     kind: 'fn' as const,
     debug: loop.toString(),
     ...(await loop(
@@ -374,7 +381,7 @@ export async function benchFn(fn: (...args: any[]) => any, opts: any = {}): Prom
       consume,
       opts.after
     )),
-  };
+  });
 }
 
 /**
@@ -484,7 +491,7 @@ export async function benchIter(iter: (...args: any[]) => any, opts: any = {}): 
           _lm2 += _ld * (_lx - _lm);
           if (_ + 1 >= ${opts.min_samples} && t >= ${opts.min_cpu_time} && _lm2 / (_ * (_ + 1)) <= ${Math.log(1 + opts.target_rel_ci) ** 2}) { _++; break; }
         }
-        if (t >= ${opts.max_cpu_time}) { $state.noisy = true; _++; break; }
+        if (t >= ${opts.max_cpu_time}) { $state.samplesUnstable = true; _++; break; }
         `
         }
       }
@@ -507,7 +514,7 @@ export async function benchIter(iter: (...args: any[]) => any, opts: any = {}): 
   const rawCount = samples.length;
   if (samples.length > opts.samples_threshold) samples = samples.slice(2, -2);
 
-  return {
+  return withLegacySampleStabilityAlias({
     samples,
     kind: 'iter' as const,
     plan: {
@@ -527,6 +534,6 @@ export async function benchIter(iter: (...args: any[]) => any, opts: any = {}): 
     avg: samples.reduce((a, v) => a + v, 0) / samples.length,
     ticks: samples.length * (!_.batch ? 1 : opts.batch_samples),
     ...(_.gc ? { gc: _.gc } : {}),
-    ...(opts.target_rel_ci ? { noisy: _.noisy ?? false } : {}),
-  };
+    ...(opts.target_rel_ci ? { samplesUnstable: _.samplesUnstable ?? false } : {}),
+  });
 }

--- a/src/bench/main.ts
+++ b/src/bench/main.ts
@@ -6,7 +6,7 @@ import { arch, colors, cpu, runtime, version } from './env.ts';
 import { measure } from './lib/measure.ts';
 import { _print, kind } from './lib/runtime.ts';
 import { renderMitata, type RenderedCollection } from './render.ts';
-import type { Collection, Context, Stats, Trial } from './types.ts';
+import type { BlockPlan, Collection, Context, Stats, Trial } from './types.ts';
 
 let FLAGS = 0;
 let $counters: any = null;
@@ -16,6 +16,24 @@ export const flags = {
   compact: 1 << 0,
   baseline: 1 << 1,
 };
+
+/**
+ * Tune overrides that replay a pilot block's plan exactly: the batching
+ * decision is forced and the sample count is fixed with no time floor, so
+ * every block does identical work regardless of environment speed.
+ */
+function planOverrides(plan?: BlockPlan): Record<string, unknown> {
+  if (!plan) return {};
+  return {
+    batch: plan.batch,
+    batch_samples: plan.batch_samples,
+    batch_unroll: plan.batch_unroll,
+    min_samples: plan.samples,
+    max_samples: plan.samples,
+    min_cpu_time: 0,
+    adaptive: false,
+  };
+}
 
 export class B {
   f: ((...args: any[]) => any) | null = null;
@@ -123,7 +141,7 @@ export class B {
     }
   }
 
-  async run(thrw = false, _tune: any = {}): Promise<Trial> {
+  async run(thrw = false, _tune: any = {}, plans?: Array<BlockPlan | undefined>): Promise<Trial> {
     const args = Object.keys(this._args);
     const kind = 0 === args.length ? 'static' : 1 === args.length ? 'args' : 'multi-args';
 
@@ -159,7 +177,7 @@ export class B {
     if (kind === 'static') {
       let stats: Stats | undefined, error: unknown;
       try {
-        stats = await measure(this.f!, tune);
+        stats = await measure(this.f!, { ...tune, ...planOverrides(plans?.[0]) });
       } catch (err) {
         error = err;
         if (thrw) throw err;
@@ -202,7 +220,7 @@ export class B {
           for (let oo = 0; oo < args.length; oo++)
             _name = _name.replaceAll(`\$${args[oo]}`, _args[args[oo]]);
           try {
-            stats = await measure(this.f!, { ...tune, args: _args });
+            stats = await measure(this.f!, { ...tune, args: _args, ...planOverrides(plans?.[o]) });
           } catch (err) {
             error = err;
             if (thrw) throw err;
@@ -334,14 +352,18 @@ async function initCounters(arch: string | null, runtime: string | null): Promis
 }
 
 /** Run one registered trial by its global registration index. */
-export async function runTrialAt(index: number, tune: any = {}): Promise<Trial> {
+export async function runTrialAt(
+  index: number,
+  tune: any = {},
+  plans?: Array<BlockPlan | undefined>
+): Promise<Trial> {
   const trials = COLLECTIONS.flatMap((c) => c.trials) as B[];
   const trial = trials[index];
   if (!trial) {
     throw new RangeError(`no bench registered at index ${index} (${trials.length} registered)`);
   }
   await initCounters(await arch(), runtime());
-  return await trial.run(false, tune);
+  return await trial.run(false, tune, plans);
 }
 
 export async function run(
@@ -377,6 +399,19 @@ export async function run(
   };
 
   await initCounters(context.arch, context.runtime);
+
+  if (opts.execute) {
+    const jobs: Array<{ trial: B; index: number }> = [];
+    let index = 0;
+    for (const collection of COLLECTIONS) {
+      for (const trial of collection.trials) {
+        const i = index++;
+        if (opts.filter.test(trial._name)) jobs.push({ trial, index: i });
+      }
+    }
+    const executed: Map<number, Trial> = await opts.execute(jobs);
+    opts.run_trial = (_trial: B, i: number) => executed.get(i)!;
+  }
 
   const layout = COLLECTIONS.map((c) => ({ name: c.name, types: c.types }));
   const format = 'string' === typeof opts.format ? opts.format : Object.keys(opts.format)[0];

--- a/src/bench/render.ts
+++ b/src/bench/render.ts
@@ -5,7 +5,7 @@ import * as histogramFmt from './format/histogram.ts';
 import * as boxplotFmt from './format/boxplot.ts';
 import * as barplotFmt from './format/barplot.ts';
 import * as lineplotFmt from './format/lineplot.ts';
-import type { Context, GcMode, Trial } from './types.ts';
+import { hasUnstableSamples, type Context, type GcMode, type Trial } from './types.ts';
 
 export interface RenderedTrial {
   highlight: false | string | null;
@@ -120,16 +120,16 @@ export function renderMitata(
         const optimized_out = r.stats!.avg < 1.42 * noop.avg;
         optimized_out_warning = optimized_out_warning || optimized_out;
 
-        const noisy = !!r.stats!.noisy;
+        const samplesUnstable = hasUnstableSamples(r.stats);
 
         if (compact) {
           let l = '';
           prev_run_gap = false;
           const avg = formatNs(r.stats!.avg).padStart(9);
-          const nw = noisy ? k_legend - 2 : k_legend;
+          const nw = samplesUnstable ? k_legend - 2 : k_legend;
           const name = truncate(r.name, nw).padEnd(nw);
 
-          if (noisy) l += !opts.colors ? '⚠ ' : ansi.yellow + '⚠' + ansi.reset + ' ';
+          if (samplesUnstable) l += !opts.colors ? '⚠ ' : ansi.yellow + '⚠' + ansi.reset + ' ';
           l += _h(name) + ' ';
           if (!opts.colors) l += avg + '/iter';
           else l += ansi.bold + ansi.yellow + avg + ansi.reset + ansi.bold + '/iter' + ansi.reset;
@@ -148,10 +148,10 @@ export function renderMitata(
         } else {
           let l = '';
           const avg = formatNs(r.stats!.avg).padStart(9);
-          const nw = noisy ? k_legend - 2 : k_legend;
+          const nw = samplesUnstable ? k_legend - 2 : k_legend;
           const name = truncate(r.name, nw).padEnd(nw);
 
-          if (noisy) l += !opts.colors ? '⚠ ' : ansi.yellow + '⚠' + ansi.reset + ' ';
+          if (samplesUnstable) l += !opts.colors ? '⚠ ' : ansi.yellow + '⚠' + ansi.reset + ' ';
           l += _h(name) + ' ';
           const p75 = formatNs(r.stats!.p75).padStart(9);
           const bins = histogramFmt.bins(r.stats!, 21, 0.99);

--- a/src/bench/render.ts
+++ b/src/bench/render.ts
@@ -68,7 +68,6 @@ export function renderMitata(
 
   let first = true;
   let optimized_out_warning = false;
-  let noisy_warning = false;
 
   for (const collection of collections) {
     let prev_run_gap = false;
@@ -122,7 +121,6 @@ export function renderMitata(
         optimized_out_warning = optimized_out_warning || optimized_out;
 
         const noisy = !!r.stats!.noisy;
-        noisy_warning = noisy_warning || noisy;
 
         if (compact) {
           let l = '';
@@ -131,7 +129,7 @@ export function renderMitata(
           const nw = noisy ? k_legend - 2 : k_legend;
           const name = truncate(r.name, nw).padEnd(nw);
 
-          if (noisy) l += !opts.colors ? '~ ' : ansi.yellow + '~' + ansi.reset + ' ';
+          if (noisy) l += !opts.colors ? '⚠ ' : ansi.yellow + '⚠' + ansi.reset + ' ';
           l += _h(name) + ' ';
           if (!opts.colors) l += avg + '/iter';
           else l += ansi.bold + ansi.yellow + avg + ansi.reset + ansi.bold + '/iter' + ansi.reset;
@@ -153,7 +151,7 @@ export function renderMitata(
           const nw = noisy ? k_legend - 2 : k_legend;
           const name = truncate(r.name, nw).padEnd(nw);
 
-          if (noisy) l += !opts.colors ? '~ ' : ansi.yellow + '~' + ansi.reset + ' ';
+          if (noisy) l += !opts.colors ? '⚠ ' : ansi.yellow + '⚠' + ansi.reset + ' ';
           l += _h(name) + ' ';
           const p75 = formatNs(r.stats!.p75).padStart(9);
           const bins = histogramFmt.bins(r.stats!, 21, 0.99);
@@ -790,22 +788,5 @@ export function renderMitata(
         pad + ansi.gray + 'https://github.com/evanwashere/mitata#writing-good-benchmarks' + ansi.reset
       );
     }
-  }
-
-  if (noisy_warning) {
-    if (!nl) print('');
-    const pad = ' '.repeat(k_legend - 13);
-    if (!opts.colors) print(pad + '~ = noisy: confidence target not reached before max cpu time');
-    else
-      print(
-        pad +
-          ansi.yellow +
-          '~' +
-          ansi.reset +
-          ansi.gray +
-          ' = ' +
-          ansi.reset +
-          'noisy: confidence target not reached before max cpu time'
-      );
   }
 }

--- a/src/bench/types.ts
+++ b/src/bench/types.ts
@@ -1,3 +1,15 @@
+/**
+ * Measurement decisions made once by a pilot block and replayed verbatim by
+ * every later block, so all blocks of a bench do identical work.
+ */
+export interface BlockPlan {
+  batch: boolean;
+  batch_samples: number;
+  batch_unroll: number;
+  /** Untrimmed sample count the pilot collected and each block replays. */
+  samples: number;
+}
+
 export interface Stats {
   debug: string;
   ticks: number;
@@ -15,6 +27,10 @@ export interface Stats {
   gc?: { avg: number; min: number; max: number; total: number };
   heap?: { avg: number; min: number; max: number; total: number };
   noisy?: boolean;
+  /** Decisions this measurement made, usable to freeze later blocks. */
+  plan?: BlockPlan;
+  /** Per-block summaries when the bench ran as multiple isolated blocks. */
+  blocks?: { medians: number[]; freqs: number[] };
 }
 
 export interface MeasureOptions {
@@ -28,6 +44,8 @@ export interface MeasureOptions {
   max_cpu_time?: number;
   batch_unroll?: number;
   batch_samples?: number;
+  /** Forces the batching decision instead of probing for it. */
+  batch?: boolean;
   warmup_samples?: number;
   batch_threshold?: number;
   warmup_threshold?: number;
@@ -88,6 +106,12 @@ export interface RunOptions {
   format?: string | Record<string, any>;
   /** Executes one registered trial. The default runs it in-process. */
   run_trial?: (trial: any, index: number) => Trial | Promise<Trial>;
+  /**
+   * Executes all filtered trials up front, keyed by registration index.
+   * Overrides run_trial and lets the executor control scheduling order,
+   * e.g. round robin block interleaving across benches.
+   */
+  execute?: (jobs: Array<{ trial: any; index: number }>) => Promise<Map<number, Trial>>;
 }
 
 export interface Collection {

--- a/src/bench/types.ts
+++ b/src/bench/types.ts
@@ -26,11 +26,25 @@ export interface Stats {
   p999: number;
   gc?: { avg: number; min: number; max: number; total: number };
   heap?: { avg: number; min: number; max: number; total: number };
+  /** Adaptive samples did not settle before the measurement time limit. */
+  samplesUnstable?: boolean;
+  /** @deprecated Use `samplesUnstable`. */
   noisy?: boolean;
   /** Decisions this measurement made, usable to freeze later blocks. */
   plan?: BlockPlan;
-  /** Per-block summaries when the bench ran as multiple isolated blocks. */
-  blocks?: { medians: number[]; freqs: number[] };
+  /** Per-block summaries when the benchmark ran in multiple fresh processes. */
+  blocks?: {
+    medians: number[];
+    /** Software calibration rates. The `freqs` name is retained for saved-result compatibility. */
+    freqs: number[];
+  };
+}
+
+/** Supports results saved before `samplesUnstable` replaced the ambiguous `noisy` name. */
+export function hasUnstableSamples(
+  stats: Pick<Stats, 'samplesUnstable' | 'noisy'> | undefined
+): boolean {
+  return stats?.samplesUnstable ?? stats?.noisy ?? false;
 }
 
 export interface MeasureOptions {

--- a/src/bench/worker.ts
+++ b/src/bench/worker.ts
@@ -57,8 +57,8 @@ async function calibrateFreq(): Promise<number> {
   return 1 / (r as any).avg;
 }
 
-/** Cheap clock probe (about 50ms) recording the machine state entering a block. */
-async function probeFreq(): Promise<number> {
+/** Short software calibration probe recording the machine state entering a block. */
+async function probeCalibrationRate(): Promise<number> {
   const r = await measure(() => {}, { batch_unroll: 1, min_cpu_time: 5e7, adaptive: false });
   return 1 / (r as any).avg;
 }
@@ -72,18 +72,21 @@ function errorReplacer(_: string, v: any): any {
 /**
  * Child mode: measure a single trial in this fresh process and write it out.
  * Skips calibration and rendering — the parent worker owns both. When part
- * of a blocked run, probes the clock and replays the pilot's plan if given.
+ * of a blocked run, records a calibration rate and replays the pilot's plan.
  */
 async function childMain(index: number): Promise<void> {
   await import(file!);
-  const freq = blockCount() > 1 ? await probeFreq() : undefined;
+  const calibrationRate = blockCount() > 1 ? await probeCalibrationRate() : undefined;
   const plans = process.env.LABS_BLOCK_PLANS
     ? (JSON.parse(process.env.LABS_BLOCK_PLANS) as BlockPlan[])
     : undefined;
   const trial = await runTrialAt(index, parseTuneEnv(), plans);
   writeFileSync(
     process.env.LABS_RESULT_FILE!,
-    JSON.stringify({ trial, ...(freq !== undefined ? { freq } : {}) }, errorReplacer)
+    JSON.stringify(
+      { trial, ...(calibrationRate !== undefined ? { calibrationRate } : {}) },
+      errorReplacer
+    )
   );
 }
 
@@ -98,7 +101,7 @@ function runTrialChild(
   trial: any,
   index: number,
   extraEnv: Record<string, string> = {}
-): { trial: Trial; freq?: number } {
+): { trial: Trial; calibrationRate?: number } {
   const resultFile = join(tmpdir(), `labs-trial-${process.pid}-${index}-${childSeq++}.json`);
   try {
     execFileSync(process.execPath, [...process.execArgv, process.argv[1]], {
@@ -151,13 +154,13 @@ function mergeRange(
 
 /**
  * Pools samples across blocks and recomputes headline stats, keeping each
- * block's median and clock probe so between-block variance stays observable.
- * Counters and debug come from the pilot. No `noisy` flag is stored for
- * blocked stats: the pilot's convergence flag reflects a fraction of the
- * budget, and spread-based noisiness is policy (it depends on minDelta), so
- * readers derive it from `blocks.medians` against the current config.
+ * block's median and calibration rate so between-run variance stays observable.
+ * Counters and debug come from the pilot. Pilot sample instability is omitted
+ * from merged stats because it reflects only a fraction of the total budget.
+ * Readers derive fresh-run consistency from `blocks.medians` against the
+ * current minDelta instead.
  */
-function mergeStats(list: Stats[], freqs: number[]): Stats {
+function mergeStats(list: Stats[], calibrationRates: number[]): Stats {
   const samples = list.flatMap((s) => s.samples).sort((a, b) => a - b);
   const weights = list.map((s) => s.samples.length);
   const heaps = list.map((s) => s.heap).filter(Boolean) as NonNullable<Stats['heap']>[];
@@ -176,14 +179,17 @@ function mergeStats(list: Stats[], freqs: number[]): Stats {
     p999: percentile(samples, 0.999),
     avg: samples.reduce((a, v) => a + v, 0) / samples.length,
     ticks: list.reduce((a, s) => a + s.ticks, 0),
+    samplesUnstable: undefined,
     noisy: undefined,
     ...(heaps.length === list.length ? { heap: mergeRange(heaps, weights) } : {}),
     ...(gcs.length === list.length ? { gc: mergeRange(gcs, weights) } : {}),
-    blocks: { medians, freqs },
+    // `freqs` is retained in the saved schema for compatibility. The values
+    // are software calibration rates, not literal hardware frequencies.
+    blocks: { medians, freqs: calibrationRates },
   };
 }
 
-function mergeBlocks(parts: Array<{ trial: Trial; freq?: number }>): Trial {
+function mergeBlocks(parts: Array<{ trial: Trial; calibrationRate?: number }>): Trial {
   if (parts.length === 1) return parts[0].trial;
   const pilot = parts[0].trial;
   return {
@@ -205,7 +211,7 @@ function mergeBlocks(parts: Array<{ trial: Trial; freq?: number }>): Trial {
         ...run,
         stats: mergeStats(
           survivors.map((p) => p.trial.runs[j]!.stats!) as Stats[],
-          survivors.map((p) => p.freq ?? 0)
+          survivors.map((p) => p.calibrationRate ?? 0)
         ),
       };
     }),
@@ -228,7 +234,7 @@ function makeBlockExecutor(blocks: number) {
       LABS_MAX_CPU_TIME: String(budget),
     };
 
-    const collected = new Map<number, Array<{ trial: Trial; freq?: number }>>();
+    const collected = new Map<number, Array<{ trial: Trial; calibrationRate?: number }>>();
     const plans = new Map<number, BlockPlan[]>();
 
     for (let block = 0; block < blocks; block++) {

--- a/src/bench/worker.ts
+++ b/src/bench/worker.ts
@@ -3,7 +3,6 @@ import { readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getBenchRegistry } from '../index.ts';
-import { blockSpread, minDetectableEffect } from '../stats.ts';
 import { measure, run } from './index.ts';
 import { runTrialAt } from './main.ts';
 import type { BlockPlan, Stats, Trial } from './types.ts';
@@ -51,12 +50,6 @@ if (!file) {
 function blockCount(): number {
   const n = Number(process.env.LABS_BLOCKS);
   return Number.isFinite(n) && n > 1 ? Math.floor(n) : 1;
-}
-
-/** Verdict threshold used for the blocked-mode noisy flag, from config via the runner. */
-function minDelta(): number {
-  const n = Number(process.env.LABS_MIN_DELTA);
-  return Number.isFinite(n) && n > 0 ? n : 0.05;
 }
 
 async function calibrateFreq(): Promise<number> {
@@ -159,10 +152,10 @@ function mergeRange(
 /**
  * Pools samples across blocks and recomputes headline stats, keeping each
  * block's median and clock probe so between-block variance stays observable.
- * Counters and debug come from the pilot. The pilot's convergence flag is
- * discarded: in blocked mode quality is judged by between-block spread, and
- * `noisy` means the estimated resolvable delta exceeds the configured
- * verdict threshold (minDelta).
+ * Counters and debug come from the pilot. No `noisy` flag is stored for
+ * blocked stats: the pilot's convergence flag reflects a fraction of the
+ * budget, and spread-based noisiness is policy (it depends on minDelta), so
+ * readers derive it from `blocks.medians` against the current config.
  */
 function mergeStats(list: Stats[], freqs: number[]): Stats {
   const samples = list.flatMap((s) => s.samples).sort((a, b) => a - b);
@@ -183,7 +176,7 @@ function mergeStats(list: Stats[], freqs: number[]): Stats {
     p999: percentile(samples, 0.999),
     avg: samples.reduce((a, v) => a + v, 0) / samples.length,
     ticks: list.reduce((a, s) => a + s.ticks, 0),
-    noisy: minDetectableEffect(blockSpread(medians), list.length) > minDelta(),
+    noisy: undefined,
     ...(heaps.length === list.length ? { heap: mergeRange(heaps, weights) } : {}),
     ...(gcs.length === list.length ? { gc: mergeRange(gcs, weights) } : {}),
     blocks: { medians, freqs },
@@ -193,13 +186,28 @@ function mergeStats(list: Stats[], freqs: number[]): Stats {
 function mergeBlocks(parts: Array<{ trial: Trial; freq?: number }>): Trial {
   if (parts.length === 1) return parts[0].trial;
   const pilot = parts[0].trial;
-  const freqs = parts.map((p) => p.freq ?? 0);
   return {
     ...pilot,
     runs: pilot.runs.map((run, j) => {
-      const statsList = parts.map((p) => p.trial.runs[j]?.stats);
-      if (run.error !== undefined || !run.stats || statsList.some((s) => !s)) return run;
-      return { ...run, stats: mergeStats(statsList as Stats[], freqs) };
+      if (run.error !== undefined || !run.stats) return run;
+      // A block whose run produced no stats is dropped rather than voiding
+      // the whole bench; the surviving blocks still replicate independently.
+      const survivors = parts.filter((p) => p.trial.runs[j]?.stats);
+      if (survivors.length < parts.length) {
+        console.error(
+          `labs: bench "${run.name || pilot.alias}" lost ` +
+            `${parts.length - survivors.length} of ${parts.length} blocks ` +
+            `(no stats produced); merging the ${survivors.length} that completed`
+        );
+      }
+      if (survivors.length < 2) return run;
+      return {
+        ...run,
+        stats: mergeStats(
+          survivors.map((p) => p.trial.runs[j]!.stats!) as Stats[],
+          survivors.map((p) => p.freq ?? 0)
+        ),
+      };
     }),
   };
 }

--- a/src/bench/worker.ts
+++ b/src/bench/worker.ts
@@ -53,6 +53,12 @@ function blockCount(): number {
   return Number.isFinite(n) && n > 1 ? Math.floor(n) : 1;
 }
 
+/** Verdict threshold used for the blocked-mode noisy flag, from config via the runner. */
+function minDelta(): number {
+  const n = Number(process.env.LABS_MIN_DELTA);
+  return Number.isFinite(n) && n > 0 ? n : 0.05;
+}
+
 async function calibrateFreq(): Promise<number> {
   const r = await measure(() => {}, { batch_unroll: 1 });
   return 1 / (r as any).avg;
@@ -155,8 +161,8 @@ function mergeRange(
  * block's median and clock probe so between-block variance stays observable.
  * Counters and debug come from the pilot. The pilot's convergence flag is
  * discarded: in blocked mode quality is judged by between-block spread, and
- * `noisy` means the machine floor is too high to resolve the default 5%
- * verdict threshold.
+ * `noisy` means the estimated resolvable delta exceeds the configured
+ * verdict threshold (minDelta).
  */
 function mergeStats(list: Stats[], freqs: number[]): Stats {
   const samples = list.flatMap((s) => s.samples).sort((a, b) => a - b);
@@ -177,7 +183,7 @@ function mergeStats(list: Stats[], freqs: number[]): Stats {
     p999: percentile(samples, 0.999),
     avg: samples.reduce((a, v) => a + v, 0) / samples.length,
     ticks: list.reduce((a, s) => a + s.ticks, 0),
-    noisy: minDetectableEffect(blockSpread(medians), list.length) > 0.05,
+    noisy: minDetectableEffect(blockSpread(medians), list.length) > minDelta(),
     ...(heaps.length === list.length ? { heap: mergeRange(heaps, weights) } : {}),
     ...(gcs.length === list.length ? { gc: mergeRange(gcs, weights) } : {}),
     blocks: { medians, freqs },

--- a/src/bench/worker.ts
+++ b/src/bench/worker.ts
@@ -3,9 +3,10 @@ import { readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getBenchRegistry } from '../index.ts';
+import { blockSpread, minDetectableEffect } from '../stats.ts';
 import { measure, run } from './index.ts';
 import { runTrialAt } from './main.ts';
-import type { Trial } from './types.ts';
+import type { BlockPlan, Stats, Trial } from './types.ts';
 
 type TuneOptions = {
   min_cpu_time?: number;
@@ -47,8 +48,19 @@ if (!file) {
   process.exit(1);
 }
 
+function blockCount(): number {
+  const n = Number(process.env.LABS_BLOCKS);
+  return Number.isFinite(n) && n > 1 ? Math.floor(n) : 1;
+}
+
 async function calibrateFreq(): Promise<number> {
   const r = await measure(() => {}, { batch_unroll: 1 });
+  return 1 / (r as any).avg;
+}
+
+/** Cheap clock probe (about 50ms) recording the machine state entering a block. */
+async function probeFreq(): Promise<number> {
+  const r = await measure(() => {}, { batch_unroll: 1, min_cpu_time: 5e7, adaptive: false });
   return 1 / (r as any).avg;
 }
 
@@ -58,22 +70,48 @@ function errorReplacer(_: string, v: any): any {
   return { message: String(v.message), stack: v.stack };
 }
 
-/** Measure one trial without calibration or rendering. */
+/**
+ * Child mode: measure a single trial in this fresh process and write it out.
+ * Skips calibration and rendering — the parent worker owns both. When part
+ * of a blocked run, probes the clock and replays the pilot's plan if given.
+ */
 async function childMain(index: number): Promise<void> {
   await import(file!);
-  const trial = await runTrialAt(index, parseTuneEnv());
-  writeFileSync(process.env.LABS_RESULT_FILE!, JSON.stringify({ trial }, errorReplacer));
+  const freq = blockCount() > 1 ? await probeFreq() : undefined;
+  const plans = process.env.LABS_BLOCK_PLANS
+    ? (JSON.parse(process.env.LABS_BLOCK_PLANS) as BlockPlan[])
+    : undefined;
+  const trial = await runTrialAt(index, parseTuneEnv(), plans);
+  writeFileSync(
+    process.env.LABS_RESULT_FILE!,
+    JSON.stringify({ trial, ...(freq !== undefined ? { freq } : {}) }, errorReplacer)
+  );
 }
 
-/** Run a trial in a fresh process to isolate its JIT and heap state. */
-function runTrialIsolated(trial: any, index: number): Trial {
-  const resultFile = join(tmpdir(), `labs-trial-${process.pid}-${index}.json`);
+let childSeq = 0;
+
+/**
+ * Runs one trial in a fresh child process (same script, same node flags,
+ * `LABS_ONLY_INDEX` selecting the trial) so each bench measures against a
+ * pristine V8 — no IC/heap contamination from earlier benches in the file.
+ */
+function runTrialChild(
+  trial: any,
+  index: number,
+  extraEnv: Record<string, string> = {}
+): { trial: Trial; freq?: number } {
+  const resultFile = join(tmpdir(), `labs-trial-${process.pid}-${index}-${childSeq++}.json`);
   try {
     execFileSync(process.execPath, [...process.execArgv, process.argv[1]], {
       stdio: ['ignore', 'inherit', 'inherit'],
-      env: { ...process.env, LABS_ONLY_INDEX: String(index), LABS_RESULT_FILE: resultFile },
+      env: {
+        ...process.env,
+        ...extraEnv,
+        LABS_ONLY_INDEX: String(index),
+        LABS_RESULT_FILE: resultFile,
+      },
     });
-    return JSON.parse(readFileSync(resultFile, 'utf-8')).trial;
+    return JSON.parse(readFileSync(resultFile, 'utf-8'));
   } catch (err) {
     throw new Error(`isolated bench "${trial?._name ?? index}" failed: ${String(err)}`, {
       cause: err,
@@ -83,12 +121,138 @@ function runTrialIsolated(trial: any, index: number): Trial {
   }
 }
 
+function runTrialIsolated(trial: any, index: number): Trial {
+  return runTrialChild(trial, index).trial;
+}
+
+/** Per run plans from a pilot trial, or null when any run failed to produce one. */
+function extractPlans(trial: Trial): BlockPlan[] | null {
+  const plans: BlockPlan[] = [];
+  for (const run of trial.runs) {
+    if (!run.stats?.plan) return null;
+    plans.push(run.stats.plan);
+  }
+  return plans;
+}
+
+const percentile = (sorted: number[], p: number) => sorted[(p * (sorted.length - 1)) | 0];
+
+function mergeRange(
+  list: Array<{ avg: number; min: number; max: number; total: number }>,
+  weights: number[]
+): { avg: number; min: number; max: number; total: number } {
+  const totalWeight = weights.reduce((a, v) => a + v, 0) || 1;
+  return {
+    avg: list.reduce((a, v, i) => a + v.avg * weights[i], 0) / totalWeight,
+    min: Math.min(...list.map((v) => v.min)),
+    max: Math.max(...list.map((v) => v.max)),
+    total: list.reduce((a, v) => a + v.total, 0),
+  };
+}
+
+/**
+ * Pools samples across blocks and recomputes headline stats, keeping each
+ * block's median and clock probe so between-block variance stays observable.
+ * Counters and debug come from the pilot. The pilot's convergence flag is
+ * discarded: in blocked mode quality is judged by between-block spread, and
+ * `noisy` means the machine floor is too high to resolve the default 5%
+ * verdict threshold.
+ */
+function mergeStats(list: Stats[], freqs: number[]): Stats {
+  const samples = list.flatMap((s) => s.samples).sort((a, b) => a - b);
+  const weights = list.map((s) => s.samples.length);
+  const heaps = list.map((s) => s.heap).filter(Boolean) as NonNullable<Stats['heap']>[];
+  const gcs = list.map((s) => s.gc).filter(Boolean) as NonNullable<Stats['gc']>[];
+  const medians = list.map((s) => s.p50);
+
+  return {
+    ...list[0],
+    samples,
+    min: samples[0],
+    max: samples[samples.length - 1],
+    p25: percentile(samples, 0.25),
+    p50: percentile(samples, 0.5),
+    p75: percentile(samples, 0.75),
+    p99: percentile(samples, 0.99),
+    p999: percentile(samples, 0.999),
+    avg: samples.reduce((a, v) => a + v, 0) / samples.length,
+    ticks: list.reduce((a, s) => a + s.ticks, 0),
+    noisy: minDetectableEffect(blockSpread(medians), list.length) > 0.05,
+    ...(heaps.length === list.length ? { heap: mergeRange(heaps, weights) } : {}),
+    ...(gcs.length === list.length ? { gc: mergeRange(gcs, weights) } : {}),
+    blocks: { medians, freqs },
+  };
+}
+
+function mergeBlocks(parts: Array<{ trial: Trial; freq?: number }>): Trial {
+  if (parts.length === 1) return parts[0].trial;
+  const pilot = parts[0].trial;
+  const freqs = parts.map((p) => p.freq ?? 0);
+  return {
+    ...pilot,
+    runs: pilot.runs.map((run, j) => {
+      const statsList = parts.map((p) => p.trial.runs[j]?.stats);
+      if (run.error !== undefined || !run.stats || statsList.some((s) => !s)) return run;
+      return { ...run, stats: mergeStats(statsList as Stats[], freqs) };
+    }),
+  };
+}
+
+/**
+ * Runs every bench as `blocks` fresh child processes. Block 0 is the pilot:
+ * it samples adaptively within a per-block budget and its measurement plan
+ * freezes the remaining blocks. Blocks are scheduled round robin across
+ * benches so each bench's blocks span the whole sitting and between-block
+ * spread samples real environment drift, not just adjacent seconds.
+ */
+function makeBlockExecutor(blocks: number) {
+  return async (jobs: Array<{ trial: any; index: number }>): Promise<Map<number, Trial>> => {
+    const tune = parseTuneEnv();
+    const budget = (tune.max_cpu_time ?? 5e9) / blocks;
+    const pilotEnv = {
+      LABS_MIN_CPU_TIME: String(Math.min(tune.min_cpu_time ?? 642e6, budget / 2)),
+      LABS_MAX_CPU_TIME: String(budget),
+    };
+
+    const collected = new Map<number, Array<{ trial: Trial; freq?: number }>>();
+    const plans = new Map<number, BlockPlan[]>();
+
+    for (let block = 0; block < blocks; block++) {
+      for (const { trial, index } of jobs) {
+        // A pilot without a full set of plans (errored runs) is not replayable
+        if (block > 0 && !plans.has(index)) continue;
+        const out = runTrialChild(
+          trial,
+          index,
+          block === 0 ? pilotEnv : { LABS_BLOCK_PLANS: JSON.stringify(plans.get(index)) }
+        );
+        let list = collected.get(index);
+        if (!list) collected.set(index, (list = []));
+        list.push(out);
+        if (block === 0) {
+          const p = extractPlans(out.trial);
+          if (p) plans.set(index, p);
+        }
+      }
+    }
+
+    const results = new Map<number, Trial>();
+    for (const { index } of jobs) results.set(index, mergeBlocks(collected.get(index)!));
+    return results;
+  };
+}
+
 async function main(): Promise<void> {
   const isolate = process.env.LABS_ISOLATE !== 'false';
+  const blocks = isolate ? blockCount() : 1;
   await import(file!);
   const result = await run({
     tune: parseTuneEnv(),
-    ...(isolate ? { run_trial: runTrialIsolated } : {}),
+    ...(isolate
+      ? blocks > 1
+        ? { execute: makeBlockExecutor(blocks) }
+        : { run_trial: runTrialIsolated }
+      : {}),
   });
   const postFreq = await calibrateFreq();
 

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -6,6 +6,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { compare, printCompareReport } from '../compare.ts';
 import type { LabsConfig } from '../config.ts';
 import { printReportBox } from '../report.ts';
+import { blockSpread } from '../stats.ts';
 import {
   type FreqSample,
   type GitInfo,
@@ -35,20 +36,26 @@ function collectEnvData(
   workerResult: WorkerResult,
   file: string,
   envData: FreqSample[],
-  noisyAliases: string[]
+  noisyAliases: string[],
+  blockSpreads: number[]
 ): void {
   const runFreq = workerResult.context.cpu.freq;
+  const blockFreqs: number[] = [];
+  for (const trial of workerResult.benchmarks) {
+    const trialFreqs = trial.runs[0]?.stats?.blocks?.freqs;
+    if (trialFreqs) blockFreqs.push(...trialFreqs.filter((f) => f > 0));
+    for (const run of trial.runs) {
+      const stats = run.stats;
+      if (stats && (stats as any).noisy) noisyAliases.push(run.name || trial.alias);
+      if (stats?.blocks) blockSpreads.push(blockSpread(stats.blocks.medians));
+    }
+  }
   envData.push({
     file,
     runFreq,
     postFreq: workerResult.environment?.postFreq ?? runFreq,
+    ...(blockFreqs.length > 0 ? { blockFreqs } : {}),
   });
-  for (const trial of workerResult.benchmarks) {
-    for (const run of trial.runs) {
-      const stats = run.stats;
-      if (stats && (stats as any).noisy) noisyAliases.push(run.name || trial.alias);
-    }
-  }
 }
 
 const WORKER_EXT = import.meta.url.endsWith('.ts') ? 'ts' : 'mjs';
@@ -98,7 +105,7 @@ function runBench(
   label: string,
   tune: Pick<
     Partial<LabsConfig>,
-    'minCpuTime' | 'minSamples' | 'maxSamples' | 'adaptive' | 'maxCpuTime' | 'isolate'
+    'minCpuTime' | 'minSamples' | 'maxSamples' | 'adaptive' | 'maxCpuTime' | 'isolate' | 'blocks'
   >,
   tagFilter?: string,
   resultFile?: string
@@ -117,6 +124,7 @@ function runBench(
       ...env,
       LABS_BENCH_FILE: pathToFileURL(file).href,
       LABS_ISOLATE: String(tune.isolate !== false),
+      LABS_BLOCKS: String(tune.blocks ?? 1),
       ...(tune.minCpuTime !== undefined ? { LABS_MIN_CPU_TIME: String(tune.minCpuTime * 1e9) } : {}),
       ...(tune.minSamples !== undefined ? { LABS_MIN_SAMPLES: String(tune.minSamples) } : {}),
       ...(tune.maxSamples !== undefined ? { LABS_MAX_SAMPLES: String(tune.maxSamples) } : {}),
@@ -234,7 +242,7 @@ export async function runCLI(args: string[]) {
     if (selected.length === 0) error('No previous selection found');
     console.log(`${CYAN}labs${RESET} ${DIM}(replaying last)${RESET}`);
   } else {
-    const flagTakesValue = new Set(['-n', '--name', '-m', '--message']);
+    const flagTakesValue = new Set(['-n', '--name', '-m', '--message', '--blocks']);
     let filterArg: string | undefined;
     for (let i = 0; i < benchArgs.length; i++) {
       const a = benchArgs[i];
@@ -291,6 +299,21 @@ export async function runCLI(args: string[]) {
   }
 
   const isolate = config.isolate !== false && !benchArgs.includes('--no-isolate');
+
+  // Saves default to blocked sampling so between-block variance is captured.
+  // `bench run` stays single-block for inner-loop speed unless asked.
+  const blocksFlag = flagValue(benchArgs, '--blocks');
+  const requestedBlocks =
+    blocksFlag !== undefined && blocksFlag !== ''
+      ? Number(blocksFlag)
+      : shouldSave
+        ? (config.blocks ?? 8)
+        : 1;
+  const blocks = isolate ? Math.max(1, Math.floor(requestedBlocks) || 1) : 1;
+  if (!isolate && requestedBlocks > 1) {
+    console.log(`${DIM}blocked sampling requires isolation - running single-block${RESET}`);
+  }
+
   const benchTune = {
     minCpuTime: config.minCpuTime,
     minSamples: config.minSamples,
@@ -298,6 +321,7 @@ export async function runCLI(args: string[]) {
     adaptive: config.adaptive,
     maxCpuTime: config.maxCpuTime,
     isolate,
+    blocks,
   };
 
   if (!shouldSave) {
@@ -311,15 +335,23 @@ export async function runCLI(args: string[]) {
     }
     const runEnvData: FreqSample[] = [];
     const runNoisyAliases: string[] = [];
+    const runBlockSpreads: number[] = [];
     let runCpu: string | null = null;
     for (const { file, resultFile } of runOutputs) {
       if (!existsSync(resultFile)) continue;
       const workerResult: WorkerResult = JSON.parse(readFileSync(resultFile, 'utf-8'));
       rmSync(resultFile);
       runCpu ??= workerResult.context.cpu.name;
-      collectEnvData(workerResult, suiteName(file), runEnvData, runNoisyAliases);
+      collectEnvData(workerResult, suiteName(file), runEnvData, runNoisyAliases, runBlockSpreads);
     }
-    printReportBox(runEnvData, runNoisyAliases, config.maxCpuTime!, undefined, runCpu);
+    printReportBox(
+      runEnvData,
+      runNoisyAliases,
+      config.maxCpuTime!,
+      undefined,
+      runCpu,
+      blocks > 1 ? { blocks, spreads: runBlockSpreads } : undefined
+    );
     return;
   }
 
@@ -371,6 +403,7 @@ export async function runCLI(args: string[]) {
   let hardwareSet = false;
   const saveEnvData: FreqSample[] = [];
   const saveNoisyAliases: string[] = [];
+  const saveBlockSpreads: number[] = [];
   let savedNoop: SavedResult['context'] | undefined;
 
   for (const { file, resultFile } of workerOutputs) {
@@ -397,7 +430,7 @@ export async function runCLI(args: string[]) {
       hardwareSet = true;
     }
 
-    collectEnvData(workerResult, suiteName(file), saveEnvData, saveNoisyAliases);
+    collectEnvData(workerResult, suiteName(file), saveEnvData, saveNoisyAliases, saveBlockSpreads);
 
     files.push({
       file: suiteName(file),
@@ -428,6 +461,7 @@ export async function runCLI(args: string[]) {
     ...(git ? { git } : {}),
     hardware,
     isolation: isolate ? 'bench' : 'file',
+    blocks,
     context: savedNoop,
     files,
     environment: { freqs: saveEnvData },
@@ -446,7 +480,14 @@ export async function runCLI(args: string[]) {
   const gitNote = git ? ` ${DIM}${gitHint(git)}${RESET}` : '';
   const saveMsg = `${GREEN}✔${RESET} Saved "${saveName}"${gitNote}${baselineNote} (${files.length} file${files.length !== 1 ? 's' : ''})`;
 
-  printReportBox(saveEnvData, saveNoisyAliases, config.maxCpuTime!, saveMsg, hardware.cpu);
+  printReportBox(
+    saveEnvData,
+    saveNoisyAliases,
+    config.maxCpuTime!,
+    saveMsg,
+    hardware.cpu,
+    blocks > 1 ? { blocks, spreads: saveBlockSpreads } : undefined
+  );
 
   if (shouldCompare) {
     const baselineName = getBaseline(labsDir);

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -5,7 +5,7 @@ import { basename, dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { compare, printCompareReport } from '../compare.ts';
 import type { LabsConfig } from '../config.ts';
-import { printReportBox } from '../report.ts';
+import { type NoisyBench, printReportBox } from '../report.ts';
 import { blockSpread } from '../stats.ts';
 import {
   type FreqSample,
@@ -36,7 +36,7 @@ function collectEnvData(
   workerResult: WorkerResult,
   file: string,
   envData: FreqSample[],
-  noisyAliases: string[],
+  noisyBenches: NoisyBench[],
   blockSpreads: number[]
 ): void {
   const runFreq = workerResult.context.cpu.freq;
@@ -46,7 +46,12 @@ function collectEnvData(
     if (trialFreqs) blockFreqs.push(...trialFreqs.filter((f) => f > 0));
     for (const run of trial.runs) {
       const stats = run.stats;
-      if (stats && (stats as any).noisy) noisyAliases.push(run.name || trial.alias);
+      if (stats && (stats as any).noisy) {
+        noisyBenches.push({
+          name: run.name || trial.alias,
+          ...(stats.blocks ? { spread: blockSpread(stats.blocks.medians) } : {}),
+        });
+      }
       if (stats?.blocks) blockSpreads.push(blockSpread(stats.blocks.medians));
     }
   }
@@ -343,7 +348,7 @@ export async function runCLI(args: string[]) {
       runOutputs.push({ file: f, resultFile });
     }
     const runEnvData: FreqSample[] = [];
-    const runNoisyAliases: string[] = [];
+    const runNoisyBenches: NoisyBench[] = [];
     const runBlockSpreads: number[] = [];
     let runCpu: string | null = null;
     for (const { file, resultFile } of runOutputs) {
@@ -351,11 +356,11 @@ export async function runCLI(args: string[]) {
       const workerResult: WorkerResult = JSON.parse(readFileSync(resultFile, 'utf-8'));
       rmSync(resultFile);
       runCpu ??= workerResult.context.cpu.name;
-      collectEnvData(workerResult, suiteName(file), runEnvData, runNoisyAliases, runBlockSpreads);
+      collectEnvData(workerResult, suiteName(file), runEnvData, runNoisyBenches, runBlockSpreads);
     }
     printReportBox(
       runEnvData,
-      runNoisyAliases,
+      runNoisyBenches,
       config.maxCpuTime!,
       undefined,
       runCpu,
@@ -411,7 +416,7 @@ export async function runCLI(args: string[]) {
   const files: SavedResult['files'] = [];
   let hardwareSet = false;
   const saveEnvData: FreqSample[] = [];
-  const saveNoisyAliases: string[] = [];
+  const saveNoisyBenches: NoisyBench[] = [];
   const saveBlockSpreads: number[] = [];
   let savedNoop: SavedResult['context'] | undefined;
 
@@ -439,7 +444,7 @@ export async function runCLI(args: string[]) {
       hardwareSet = true;
     }
 
-    collectEnvData(workerResult, suiteName(file), saveEnvData, saveNoisyAliases, saveBlockSpreads);
+    collectEnvData(workerResult, suiteName(file), saveEnvData, saveNoisyBenches, saveBlockSpreads);
 
     files.push({
       file: suiteName(file),
@@ -491,7 +496,7 @@ export async function runCLI(args: string[]) {
 
   printReportBox(
     saveEnvData,
-    saveNoisyAliases,
+    saveNoisyBenches,
     config.maxCpuTime!,
     saveMsg,
     hardware.cpu,

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -117,13 +117,7 @@ function runBench(
   label: string,
   tune: Pick<
     Partial<LabsConfig>,
-    | 'minCpuTime'
-    | 'minSamples'
-    | 'maxSamples'
-    | 'adaptive'
-    | 'maxCpuTime'
-    | 'isolate'
-    | 'blocks'
+    'minCpuTime' | 'minSamples' | 'maxSamples' | 'adaptive' | 'maxCpuTime' | 'isolate' | 'blocks'
   >,
   tagFilter?: string,
   resultFile?: string
@@ -403,7 +397,8 @@ export async function runCLI(args: string[]) {
     }
     return new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, 19);
   };
-  const saveName = flagValue(benchArgs, '-n') ?? flagValue(benchArgs, '--name') ?? defaultName();
+  const suppliedName = flagValue(benchArgs, '-n') ?? flagValue(benchArgs, '--name');
+  const saveName = suppliedName ?? defaultName();
 
   const forceOverwrite = benchArgs.includes('--force') || benchArgs.includes('-f');
   if (!forceOverwrite && resultExists(labsDir, saveName)) {
@@ -523,9 +518,10 @@ export async function runCLI(args: string[]) {
     markedBaseline = true;
   }
 
-  const baselineNote = markedBaseline ? ` ${CYAN}(baseline)${RESET}` : '';
-  const gitNote = git ? ` ${DIM}${gitHint(git)}${RESET}` : '';
-  const saveMsg = `${GREEN}✔${RESET} Saved "${saveName}"${gitNote}${baselineNote} (${files.length} file${files.length !== 1 ? 's' : ''})`;
+  const gitNote = git && suppliedName ? ` ${DIM}${gitHint(git)}${RESET}` : '';
+  const fileNote = `${files.length} file${files.length !== 1 ? 's' : ''}`;
+  const details = markedBaseline ? `${CYAN}baseline${RESET}, ${fileNote}` : fileNote;
+  const saveMsg = `${GREEN}✔${RESET} Saved "${saveName}"${gitNote} (${details})`;
 
   printReportBox(
     saveEnvData,

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -105,7 +105,14 @@ function runBench(
   label: string,
   tune: Pick<
     Partial<LabsConfig>,
-    'minCpuTime' | 'minSamples' | 'maxSamples' | 'adaptive' | 'maxCpuTime' | 'isolate' | 'blocks'
+    | 'minCpuTime'
+    | 'minSamples'
+    | 'maxSamples'
+    | 'adaptive'
+    | 'maxCpuTime'
+    | 'isolate'
+    | 'blocks'
+    | 'minDelta'
   >,
   tagFilter?: string,
   resultFile?: string
@@ -125,6 +132,7 @@ function runBench(
       LABS_BENCH_FILE: pathToFileURL(file).href,
       LABS_ISOLATE: String(tune.isolate !== false),
       LABS_BLOCKS: String(tune.blocks ?? 1),
+      ...(tune.minDelta !== undefined ? { LABS_MIN_DELTA: String(tune.minDelta) } : {}),
       ...(tune.minCpuTime !== undefined ? { LABS_MIN_CPU_TIME: String(tune.minCpuTime * 1e9) } : {}),
       ...(tune.minSamples !== undefined ? { LABS_MIN_SAMPLES: String(tune.minSamples) } : {}),
       ...(tune.maxSamples !== undefined ? { LABS_MAX_SAMPLES: String(tune.maxSamples) } : {}),
@@ -322,6 +330,7 @@ export async function runCLI(args: string[]) {
     maxCpuTime: config.maxCpuTime,
     isolate,
     blocks,
+    minDelta: config.minDelta,
   };
 
   if (!shouldSave) {
@@ -350,7 +359,7 @@ export async function runCLI(args: string[]) {
       config.maxCpuTime!,
       undefined,
       runCpu,
-      blocks > 1 ? { blocks, spreads: runBlockSpreads } : undefined
+      blocks > 1 ? { blocks, spreads: runBlockSpreads, minDelta: config.minDelta } : undefined
     );
     return;
   }
@@ -486,7 +495,7 @@ export async function runCLI(args: string[]) {
     config.maxCpuTime!,
     saveMsg,
     hardware.cpu,
-    blocks > 1 ? { blocks, spreads: saveBlockSpreads } : undefined
+    blocks > 1 ? { blocks, spreads: saveBlockSpreads, minDelta: config.minDelta } : undefined
   );
 
   if (shouldCompare) {

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -6,7 +6,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { compare, printCompareReport } from '../compare.ts';
 import type { LabsConfig } from '../config.ts';
 import { type NoisyBench, printReportBox } from '../report.ts';
-import { blockSpread } from '../stats.ts';
+import { blockSpread, clockExplainedFraction } from '../stats.ts';
 import {
   type FreqSample,
   type GitInfo,
@@ -37,7 +37,8 @@ function collectEnvData(
   file: string,
   envData: FreqSample[],
   noisyBenches: NoisyBench[],
-  blockSpreads: number[]
+  blockSpreads: number[],
+  clockExplained: number[]
 ): void {
   const runFreq = workerResult.context.cpu.freq;
   const blockFreqs: number[] = [];
@@ -52,7 +53,10 @@ function collectEnvData(
           ...(stats.blocks ? { spread: blockSpread(stats.blocks.medians) } : {}),
         });
       }
-      if (stats?.blocks) blockSpreads.push(blockSpread(stats.blocks.medians));
+      if (stats?.blocks) {
+        blockSpreads.push(blockSpread(stats.blocks.medians));
+        clockExplained.push(clockExplainedFraction(stats.blocks.medians, stats.blocks.freqs));
+      }
     }
   }
   envData.push({
@@ -350,13 +354,21 @@ export async function runCLI(args: string[]) {
     const runEnvData: FreqSample[] = [];
     const runNoisyBenches: NoisyBench[] = [];
     const runBlockSpreads: number[] = [];
+    const runClockExplained: number[] = [];
     let runCpu: string | null = null;
     for (const { file, resultFile } of runOutputs) {
       if (!existsSync(resultFile)) continue;
       const workerResult: WorkerResult = JSON.parse(readFileSync(resultFile, 'utf-8'));
       rmSync(resultFile);
       runCpu ??= workerResult.context.cpu.name;
-      collectEnvData(workerResult, suiteName(file), runEnvData, runNoisyBenches, runBlockSpreads);
+      collectEnvData(
+        workerResult,
+        suiteName(file),
+        runEnvData,
+        runNoisyBenches,
+        runBlockSpreads,
+        runClockExplained
+      );
     }
     printReportBox(
       runEnvData,
@@ -364,7 +376,14 @@ export async function runCLI(args: string[]) {
       config.maxCpuTime!,
       undefined,
       runCpu,
-      blocks > 1 ? { blocks, spreads: runBlockSpreads, minDelta: config.minDelta } : undefined
+      blocks > 1
+        ? {
+            blocks,
+            spreads: runBlockSpreads,
+            minDelta: config.minDelta,
+            clockExplained: runClockExplained,
+          }
+        : undefined
     );
     return;
   }
@@ -418,6 +437,7 @@ export async function runCLI(args: string[]) {
   const saveEnvData: FreqSample[] = [];
   const saveNoisyBenches: NoisyBench[] = [];
   const saveBlockSpreads: number[] = [];
+  const saveClockExplained: number[] = [];
   let savedNoop: SavedResult['context'] | undefined;
 
   for (const { file, resultFile } of workerOutputs) {
@@ -444,7 +464,14 @@ export async function runCLI(args: string[]) {
       hardwareSet = true;
     }
 
-    collectEnvData(workerResult, suiteName(file), saveEnvData, saveNoisyBenches, saveBlockSpreads);
+    collectEnvData(
+      workerResult,
+      suiteName(file),
+      saveEnvData,
+      saveNoisyBenches,
+      saveBlockSpreads,
+      saveClockExplained
+    );
 
     files.push({
       file: suiteName(file),
@@ -500,7 +527,14 @@ export async function runCLI(args: string[]) {
     config.maxCpuTime!,
     saveMsg,
     hardware.cpu,
-    blocks > 1 ? { blocks, spreads: saveBlockSpreads, minDelta: config.minDelta } : undefined
+    blocks > 1
+      ? {
+          blocks,
+          spreads: saveBlockSpreads,
+          minDelta: config.minDelta,
+          clockExplained: saveClockExplained,
+        }
+      : undefined
   );
 
   if (shouldCompare) {

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -3,10 +3,11 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync
 import { createRequire } from 'node:module';
 import { basename, dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { hasUnstableSamples } from '../bench/types.ts';
 import { compare, printCompareReport } from '../compare.ts';
 import type { LabsConfig } from '../config.ts';
-import { type NoisyBench, printReportBox } from '../report.ts';
-import { benchResolution, blockSpread, clockExplainedFraction } from '../stats.ts';
+import { type StabilityAffectedBenchmark, printReportBox } from '../report.ts';
+import { calibrationExplainedFraction, comparisonResolution, runMedianSpread } from '../stats.ts';
 import {
   type FreqSample,
   type GitInfo,
@@ -32,34 +33,37 @@ import { runListCommand } from './commands/list.ts';
 import { runPruneCommand } from './commands/prune.ts';
 import { error, gitHint } from './utils.ts';
 
-function collectEnvData(
+function collectReportData(
   workerResult: WorkerResult,
   file: string,
   minDelta: number,
   envData: FreqSample[],
-  noisyBenches: NoisyBench[],
-  blockSpreads: number[],
-  clockExplained: number[]
+  affectedBenchmarks: StabilityAffectedBenchmark[],
+  runMedianSpreads: number[],
+  calibrationExplainedFractions: number[]
 ): void {
   const runFreq = workerResult.context.cpu.freq;
   for (const trial of workerResult.benchmarks) {
     for (const run of trial.runs) {
       const stats = run.stats;
       if (!stats) continue;
-      // Blocked stats derive noisiness from spread against the current
-      // config; single-block stats carry the engine's convergence flag.
-      const noisy = stats.blocks
-        ? benchResolution(stats.blocks.medians) > minDelta
-        : !!(stats as any).noisy;
-      if (noisy) {
-        noisyBenches.push({
+      // Fresh runs use comparison resolution; single runs use adaptive
+      // sample stability. These are separate signals with separate causes.
+      const runsInconsistent = stats.blocks
+        ? comparisonResolution(stats.blocks.medians) > minDelta
+        : false;
+      const samplesUnstable = !stats.blocks && hasUnstableSamples(stats);
+      if (runsInconsistent || samplesUnstable) {
+        affectedBenchmarks.push({
           name: run.name || trial.alias,
-          ...(stats.blocks ? { spread: blockSpread(stats.blocks.medians) } : {}),
+          ...(stats.blocks ? { runMedianSpread: runMedianSpread(stats.blocks.medians) } : {}),
         });
       }
       if (stats.blocks) {
-        blockSpreads.push(blockSpread(stats.blocks.medians));
-        clockExplained.push(clockExplainedFraction(stats.blocks.medians, stats.blocks.freqs));
+        runMedianSpreads.push(runMedianSpread(stats.blocks.medians));
+        calibrationExplainedFractions.push(
+          calibrationExplainedFraction(stats.blocks.medians, stats.blocks.freqs)
+        );
       }
     }
   }
@@ -350,37 +354,37 @@ export async function runCLI(args: string[]) {
       runOutputs.push({ file: f, resultFile });
     }
     const runEnvData: FreqSample[] = [];
-    const runNoisyBenches: NoisyBench[] = [];
-    const runBlockSpreads: number[] = [];
-    const runClockExplained: number[] = [];
+    const runAffectedBenchmarks: StabilityAffectedBenchmark[] = [];
+    const runMedianSpreads: number[] = [];
+    const runCalibrationExplainedFractions: number[] = [];
     let runCpu: string | null = null;
     for (const { file, resultFile } of runOutputs) {
       if (!existsSync(resultFile)) continue;
       const workerResult: WorkerResult = JSON.parse(readFileSync(resultFile, 'utf-8'));
       rmSync(resultFile);
       runCpu ??= workerResult.context.cpu.name;
-      collectEnvData(
+      collectReportData(
         workerResult,
         suiteName(file),
         config.minDelta,
         runEnvData,
-        runNoisyBenches,
-        runBlockSpreads,
-        runClockExplained
+        runAffectedBenchmarks,
+        runMedianSpreads,
+        runCalibrationExplainedFractions
       );
     }
     printReportBox(
       runEnvData,
-      runNoisyBenches,
+      runAffectedBenchmarks,
       config.maxCpuTime!,
       undefined,
       runCpu,
       blocks > 1
         ? {
-            blocks,
-            spreads: runBlockSpreads,
+            freshRuns: blocks,
+            medianSpreads: runMedianSpreads,
             minDelta: config.minDelta,
-            clockExplained: runClockExplained,
+            calibrationExplainedFractions: runCalibrationExplainedFractions,
           }
         : undefined
     );
@@ -435,9 +439,9 @@ export async function runCLI(args: string[]) {
   const files: SavedResult['files'] = [];
   let hardwareSet = false;
   const saveEnvData: FreqSample[] = [];
-  const saveNoisyBenches: NoisyBench[] = [];
-  const saveBlockSpreads: number[] = [];
-  const saveClockExplained: number[] = [];
+  const saveAffectedBenchmarks: StabilityAffectedBenchmark[] = [];
+  const saveRunMedianSpreads: number[] = [];
+  const saveCalibrationExplainedFractions: number[] = [];
   let savedNoop: SavedResult['context'] | undefined;
 
   for (const { file, resultFile } of workerOutputs) {
@@ -464,14 +468,14 @@ export async function runCLI(args: string[]) {
       hardwareSet = true;
     }
 
-    collectEnvData(
+    collectReportData(
       workerResult,
       suiteName(file),
       config.minDelta,
       saveEnvData,
-      saveNoisyBenches,
-      saveBlockSpreads,
-      saveClockExplained
+      saveAffectedBenchmarks,
+      saveRunMedianSpreads,
+      saveCalibrationExplainedFractions
     );
 
     files.push({
@@ -525,16 +529,16 @@ export async function runCLI(args: string[]) {
 
   printReportBox(
     saveEnvData,
-    saveNoisyBenches,
+    saveAffectedBenchmarks,
     config.maxCpuTime!,
     saveMsg,
     hardware.cpu,
     blocks > 1
       ? {
-          blocks,
-          spreads: saveBlockSpreads,
+          freshRuns: blocks,
+          medianSpreads: saveRunMedianSpreads,
           minDelta: config.minDelta,
-          clockExplained: saveClockExplained,
+          calibrationExplainedFractions: saveCalibrationExplainedFractions,
         }
       : undefined
   );

--- a/src/cli/runner.ts
+++ b/src/cli/runner.ts
@@ -6,7 +6,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { compare, printCompareReport } from '../compare.ts';
 import type { LabsConfig } from '../config.ts';
 import { type NoisyBench, printReportBox } from '../report.ts';
-import { blockSpread, clockExplainedFraction } from '../stats.ts';
+import { benchResolution, blockSpread, clockExplainedFraction } from '../stats.ts';
 import {
   type FreqSample,
   type GitInfo,
@@ -24,7 +24,7 @@ import {
   trimStats,
   uniqueResultName,
 } from '../store.ts';
-import { BLUE, CYAN, DIM, GREEN, RED, RESET } from '../utils/ansi.ts';
+import { BLUE, CYAN, DIM, GREEN, RED, RESET, YELLOW } from '../utils/ansi.ts';
 import { runBaselineCommand } from './commands/baseline.ts';
 import { runCompareCommand } from './commands/compare.ts';
 import { runDeleteCommand } from './commands/delete.ts';
@@ -35,25 +35,29 @@ import { error, gitHint } from './utils.ts';
 function collectEnvData(
   workerResult: WorkerResult,
   file: string,
+  minDelta: number,
   envData: FreqSample[],
   noisyBenches: NoisyBench[],
   blockSpreads: number[],
   clockExplained: number[]
 ): void {
   const runFreq = workerResult.context.cpu.freq;
-  const blockFreqs: number[] = [];
   for (const trial of workerResult.benchmarks) {
-    const trialFreqs = trial.runs[0]?.stats?.blocks?.freqs;
-    if (trialFreqs) blockFreqs.push(...trialFreqs.filter((f) => f > 0));
     for (const run of trial.runs) {
       const stats = run.stats;
-      if (stats && (stats as any).noisy) {
+      if (!stats) continue;
+      // Blocked stats derive noisiness from spread against the current
+      // config; single-block stats carry the engine's convergence flag.
+      const noisy = stats.blocks
+        ? benchResolution(stats.blocks.medians) > minDelta
+        : !!(stats as any).noisy;
+      if (noisy) {
         noisyBenches.push({
           name: run.name || trial.alias,
           ...(stats.blocks ? { spread: blockSpread(stats.blocks.medians) } : {}),
         });
       }
-      if (stats?.blocks) {
+      if (stats.blocks) {
         blockSpreads.push(blockSpread(stats.blocks.medians));
         clockExplained.push(clockExplainedFraction(stats.blocks.medians, stats.blocks.freqs));
       }
@@ -63,7 +67,6 @@ function collectEnvData(
     file,
     runFreq,
     postFreq: workerResult.environment?.postFreq ?? runFreq,
-    ...(blockFreqs.length > 0 ? { blockFreqs } : {}),
   });
 }
 
@@ -121,7 +124,6 @@ function runBench(
     | 'maxCpuTime'
     | 'isolate'
     | 'blocks'
-    | 'minDelta'
   >,
   tagFilter?: string,
   resultFile?: string
@@ -141,7 +143,6 @@ function runBench(
       LABS_BENCH_FILE: pathToFileURL(file).href,
       LABS_ISOLATE: String(tune.isolate !== false),
       LABS_BLOCKS: String(tune.blocks ?? 1),
-      ...(tune.minDelta !== undefined ? { LABS_MIN_DELTA: String(tune.minDelta) } : {}),
       ...(tune.minCpuTime !== undefined ? { LABS_MIN_CPU_TIME: String(tune.minCpuTime * 1e9) } : {}),
       ...(tune.minSamples !== undefined ? { LABS_MIN_SAMPLES: String(tune.minSamples) } : {}),
       ...(tune.maxSamples !== undefined ? { LABS_MAX_SAMPLES: String(tune.maxSamples) } : {}),
@@ -177,6 +178,8 @@ function captureGitInfo(dir: string): GitInfo | undefined {
 
 /** Parse a named flag value: --flag value -> value, or undefined if flag absent. */
 function flagValue(args: string[], flag: string): string | undefined {
+  const joined = args.find((a) => a.startsWith(`${flag}=`));
+  if (joined !== undefined) return joined.slice(flag.length + 1);
   const i = args.indexOf(flag);
   if (i === -1) return undefined;
   const next = args[i + 1];
@@ -320,15 +323,17 @@ export async function runCLI(args: string[]) {
   // Saves default to blocked sampling so between-block variance is captured.
   // `bench run` stays single-block for inner-loop speed unless asked.
   const blocksFlag = flagValue(benchArgs, '--blocks');
+  if (blocksFlag !== undefined && (!Number.isInteger(Number(blocksFlag)) || Number(blocksFlag) < 1)) {
+    error(`Invalid --blocks value "${blocksFlag}" — expected an integer ≥ 1`);
+  }
   const requestedBlocks =
-    blocksFlag !== undefined && blocksFlag !== ''
-      ? Number(blocksFlag)
-      : shouldSave
-        ? (config.blocks ?? 8)
-        : 1;
-  const blocks = isolate ? Math.max(1, Math.floor(requestedBlocks) || 1) : 1;
+    blocksFlag !== undefined ? Number(blocksFlag) : shouldSave ? (config.blocks ?? 8) : 1;
+  const blocks = isolate ? requestedBlocks : 1;
   if (!isolate && requestedBlocks > 1) {
-    console.log(`${DIM}blocked sampling requires isolation - running single-block${RESET}`);
+    console.log(
+      `${YELLOW}⚠ blocked sampling requires isolation — running single-block; ` +
+        `compare verdicts need block replication, so this ${shouldSave ? 'save' : 'run'} cannot receive them${RESET}`
+    );
   }
 
   const benchTune = {
@@ -339,7 +344,6 @@ export async function runCLI(args: string[]) {
     maxCpuTime: config.maxCpuTime,
     isolate,
     blocks,
-    minDelta: config.minDelta,
   };
 
   if (!shouldSave) {
@@ -364,6 +368,7 @@ export async function runCLI(args: string[]) {
       collectEnvData(
         workerResult,
         suiteName(file),
+        config.minDelta,
         runEnvData,
         runNoisyBenches,
         runBlockSpreads,
@@ -467,6 +472,7 @@ export async function runCLI(args: string[]) {
     collectEnvData(
       workerResult,
       suiteName(file),
+      config.minDelta,
       saveEnvData,
       saveNoisyBenches,
       saveBlockSpreads,

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -326,6 +326,7 @@ function benchKey(
  * probe noise than about the clock, and skipping would eat real verdicts.
  */
 const CLOCK_GATE_MIN_DIFF = 0.02;
+const CLOCK_CONFOUNDED_PREFIX = 'clock-confounded — ';
 
 /**
  * Re-judges a bench in cycles instead of time and returns a skip reason when
@@ -360,8 +361,8 @@ function clockConfounded(
   if (cyclesVerdict === timeVerdict) return undefined;
 
   return (
-    `clock-confounded — time-based verdict "${timeVerdict}" but cycles-based "${cyclesVerdict}" ` +
-    `(median clocks ${bClock.toFixed(2)} vs ${cClock.toFixed(2)} GHz)`
+    `${CLOCK_CONFOUNDED_PREFIX}${timeVerdict}→${cyclesVerdict} · ` +
+    `${bClock.toFixed(2)}→${cClock.toFixed(2)}`
   );
 }
 
@@ -670,7 +671,19 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
 
   if (skipped.length > 0) {
     console.log(`\n${YELLOW}skipped (${skipped.length})${RESET}`);
-    for (const b of skipped) {
+    const clockConfounded = skipped.filter((b) => b.reason.startsWith(CLOCK_CONFOUNDED_PREFIX));
+    const otherSkipped = skipped.filter((b) => !b.reason.startsWith(CLOCK_CONFOUNDED_PREFIX));
+
+    if (clockConfounded.length > 0) {
+      console.log(`  ${YELLOW}clock-confounded${RESET}`);
+      for (const b of clockConfounded) {
+        const label = truncate(b.key.name || b.key.group || 'anonymous');
+        const detail = b.reason.slice(CLOCK_CONFOUNDED_PREFIX.length);
+        console.log(`  ${DIM}· ${label}${RESET}  ${YELLOW}${detail}${RESET}`);
+      }
+    }
+
+    for (const b of otherSkipped) {
       const label = truncate(b.key.name || b.key.group || 'anonymous');
       console.log(`  ${DIM}· ${label}${RESET}  ${YELLOW}${b.reason}${RESET}`);
     }

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -26,7 +26,7 @@ const CLOCK_COMPARE_THRESHOLD = 0.05;
 
 function medianFreq(freqs: FreqSample[]): number {
   if (freqs.length === 0) return 0;
-  const all = freqs.flatMap((s) => [s.runFreq, s.postFreq]);
+  const all = freqs.flatMap((s) => [s.runFreq, s.postFreq, ...(s.blockFreqs ?? [])]);
   return median(all);
 }
 
@@ -43,7 +43,7 @@ export const checkHardwareMatch: EnvironmentCheck = (baseline, candidate) => {
 
 function freqDrift(freqs: FreqSample[]): number {
   if (freqs.length === 0) return 0;
-  const all = freqs.flatMap((s) => [s.runFreq, s.postFreq]);
+  const all = freqs.flatMap((s) => [s.runFreq, s.postFreq, ...(s.blockFreqs ?? [])]);
   const min = Math.min(...all);
   const max = Math.max(...all);
   return (max - min) / ((max + min) / 2);
@@ -99,7 +99,21 @@ export const warnIsolationMismatch: EnvironmentWarning = (baseline, candidate) =
   ];
 };
 
-export const ENVIRONMENT_WARNINGS: EnvironmentWarning[] = [warnClockDrift, warnIsolationMismatch];
+export const warnBlocksMismatch: EnvironmentWarning = (baseline, candidate) => {
+  const b = baseline.blocks ?? 1;
+  const c = candidate.blocks ?? 1;
+  if (b === c) return [];
+  return [
+    `runs used different block counts (baseline: ${b}, candidate: ${c}) — ` +
+      `single-block spreads exclude between-process variance, so significance may be overstated`,
+  ];
+};
+
+export const ENVIRONMENT_WARNINGS: EnvironmentWarning[] = [
+  warnClockDrift,
+  warnIsolationMismatch,
+  warnBlocksMismatch,
+];
 
 /** All environment checks in order. Any failure blocks the entire comparison. */
 export const ENVIRONMENT_CHECKS: EnvironmentCheck[] = [checkHardwareMatch];

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -15,6 +15,8 @@ type EnvironmentCheck = (baseline: SavedResult, candidate: SavedResult) => Check
 interface BenchData {
   samples: number[];
   noisy: boolean;
+  /** Per-block medians, the independent experimental units. */
+  blocks?: number[];
 }
 
 type BenchCheck = (baseline: BenchData, candidate: BenchData) => CheckResult;
@@ -105,7 +107,7 @@ export const warnBlocksMismatch: EnvironmentWarning = (baseline, candidate) => {
   if (b === c) return [];
   return [
     `runs used different block counts (baseline: ${b}, candidate: ${c}) — ` +
-      `single-block spreads exclude between-process variance, so significance may be overstated`,
+      `benches without ≥${MIN_BLOCKS} blocks on both sides are skipped`,
   ];
 };
 
@@ -122,40 +124,36 @@ export const ENVIRONMENT_CHECKS: EnvironmentCheck[] = [checkHardwareMatch];
 
 export const checkNotNoisy: BenchCheck = (baseline, candidate) => {
   if (baseline.noisy && candidate.noisy)
-    return { ok: false, reason: 'noisy — insufficient or unconverged samples in both runs' };
+    return { ok: false, reason: 'noisy — measurement variance too high for a verdict in both runs' };
   if (baseline.noisy)
-    return { ok: false, reason: 'noisy — baseline did not collect enough stable samples' };
+    return { ok: false, reason: 'noisy — baseline variance too high for a verdict' };
   if (candidate.noisy)
-    return { ok: false, reason: 'noisy — candidate did not collect enough stable samples' };
+    return { ok: false, reason: 'noisy — candidate variance too high for a verdict' };
   return { ok: true };
 };
 
-/** MW-U normal approximation is unreliable below this threshold. */
-const MW_U_MIN_SAMPLES = 14;
+/**
+ * Samples within one process are correlated, so fresh-process blocks are the
+ * independent experimental units and verdicts require block replication on
+ * both sides. Five per side is the smallest count where the exact
+ * Mann-Whitney test can reach significance at alpha 0.05 (min p = 2/252).
+ */
+const MIN_BLOCKS = 5;
 
-export const checkMinSamples: BenchCheck = (baseline, candidate) => {
-  const bN = baseline.samples.length;
-  const cN = candidate.samples.length;
-  if (bN < MW_U_MIN_SAMPLES && cN < MW_U_MIN_SAMPLES)
-    return {
-      ok: false,
-      reason: `too few samples for MW-U (baseline: ${bN}, candidate: ${cN}; need ≥${MW_U_MIN_SAMPLES})`,
-    };
-  if (bN < MW_U_MIN_SAMPLES)
-    return {
-      ok: false,
-      reason: `baseline has too few samples for MW-U (${bN}; need ≥${MW_U_MIN_SAMPLES})`,
-    };
-  if (cN < MW_U_MIN_SAMPLES)
-    return {
-      ok: false,
-      reason: `candidate has too few samples for MW-U (${cN}; need ≥${MW_U_MIN_SAMPLES})`,
-    };
-  return { ok: true };
+export const checkBlockReplication: BenchCheck = (baseline, candidate) => {
+  const bN = baseline.blocks?.length ?? 1;
+  const cN = candidate.blocks?.length ?? 1;
+  if (bN >= MIN_BLOCKS && cN >= MIN_BLOCKS) return { ok: true };
+  return {
+    ok: false,
+    reason:
+      `insufficient block replication (baseline: ${bN}, candidate: ${cN}; need ≥${MIN_BLOCKS}) — ` +
+      `re-save with blocked sampling`,
+  };
 };
 
 /** All per-bench checks in order. Any failure skips that bench with a reason. */
-export const BENCH_CHECKS: BenchCheck[] = [checkNotNoisy, checkMinSamples];
+export const BENCH_CHECKS: BenchCheck[] = [checkNotNoisy, checkBlockReplication];
 
 // ─── Data types ──────────────────────────────────────────────────────────────
 
@@ -221,30 +219,23 @@ function trialRuns(trial: ComparableTrial): Array<{
   samples: number[];
   p99: number;
   noisy: boolean;
+  blocks?: number[];
 }> {
   const alias = (trial as any).alias ?? 'anonymous';
   const runs = (trial as any).runs as Array<any> | undefined;
+  const fromStats = (name: string, stats: any) => ({
+    name,
+    samples: Array.isArray(stats?.samples) ? stats.samples : [],
+    p99: typeof stats?.p99 === 'number' ? stats.p99 : 0,
+    noisy: !!stats?.noisy,
+    ...(Array.isArray(stats?.blocks?.medians) ? { blocks: stats.blocks.medians } : {}),
+  });
+
   if (Array.isArray(runs) && runs.length > 0) {
-    return runs.map((run) => {
-      const stats = run?.stats;
-      return {
-        name: run?.name ?? alias,
-        samples: Array.isArray(stats?.samples) ? stats.samples : [],
-        p99: typeof stats?.p99 === 'number' ? stats.p99 : 0,
-        noisy: !!stats?.noisy,
-      };
-    });
+    return runs.map((run) => fromStats(run?.name ?? alias, run?.stats));
   }
 
-  const stats = (trial as any).stats;
-  return [
-    {
-      name: alias,
-      samples: Array.isArray(stats?.samples) ? stats.samples : [],
-      p99: typeof stats?.p99 === 'number' ? stats.p99 : 0,
-      noisy: !!stats?.noisy,
-    },
-  ];
+  return [fromStats(alias, (trial as any).stats)];
 }
 
 // ─── Index helpers ───────────────────────────────────────────────────────────
@@ -254,6 +245,7 @@ interface IndexEntry {
   p99: number;
   samples: number[];
   noisy: boolean;
+  blocks?: number[];
 }
 
 function buildIndex(result: SavedResult): Map<string, IndexEntry> {
@@ -267,6 +259,7 @@ function buildIndex(result: SavedResult): Map<string, IndexEntry> {
           p99: run.p99,
           samples: run.samples,
           noisy: run.noisy,
+          ...(run.blocks ? { blocks: run.blocks } : {}),
         });
       }
     }
@@ -356,8 +349,8 @@ export function compare(
         }
 
         const benchData = {
-          baseline: { samples: base.samples, noisy: base.noisy },
-          candidate: { samples: run.samples, noisy: run.noisy },
+          baseline: { samples: base.samples, noisy: base.noisy, blocks: base.blocks },
+          candidate: { samples: run.samples, noisy: run.noisy, blocks: run.blocks },
         };
 
         let skipReason: string | undefined;
@@ -377,7 +370,10 @@ export function compare(
         const candidateMedian = median(run.samples);
         const deltaP50 = base.median > 0 ? (candidateMedian - base.median) / base.median : 0;
         const deltaP99 = base.p99 > 0 ? (run.p99 - base.p99) / base.p99 : 0;
-        const { verdict, p, d, effectiveMinDelta } = classify(base.samples, run.samples, opts);
+        // Verdicts test block medians: samples within a process are correlated,
+        // so pooled samples would shrink p arbitrarily without independent
+        // replication. Pooled data remains for the display columns only.
+        const { verdict, p, d, effectiveMinDelta } = classify(base.blocks!, run.blocks!, opts);
 
         benches.push({
           kind: 'eligible',
@@ -431,7 +427,7 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
   );
   console.log(`${DIM}${result.hardware.cpu ?? 'unknown CPU'}${RESET}`);
   console.log(
-    `${DIM}Mann-Whitney U  α=${config.alpha}  minΔ=${(config.minDelta * 100).toFixed(0)}%  cliff's d≥${config.minEffect}${RESET}\n`
+    `${DIM}Mann-Whitney U on block medians  α=${config.alpha}  minΔ=${(config.minDelta * 100).toFixed(0)}%  cliff's d≥${config.minEffect}${RESET}\n`
   );
 
   if (result.environmentWarnings.length > 0) {

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -661,7 +661,7 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
 
     if (sawNoisy) {
       console.log(
-        `${YELLOW}⚠${RESET} ${DIM}Neutral means inconclusive at the shown resolution.${RESET}`
+        `${YELLOW}⚠ Limited resolution:${RESET} ${DIM}Neutral results are inconclusive at the shown resolution.${RESET}`
       );
       console.log('');
     }

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,6 +1,13 @@
 import type { LabsConfig } from './config.ts';
 import { renderDistributions } from './histogram.ts';
-import { type ClassifyOptions, type Verdict, classify, median, minMannWhitneyP } from './stats.ts';
+import {
+  type ClassifyOptions,
+  type Verdict,
+  benchResolution,
+  classify,
+  median,
+  minMannWhitneyP,
+} from './stats.ts';
 import { type FreqSample, type GitInfo, type SavedResult, isEnvironmentStable } from './store.ts';
 import { gitHint } from './cli/utils.ts';
 import { BOLD, CYAN, DARK_GRAY, DIM, GRAY, GREEN, RED, RESET, WHITE, YELLOW } from './utils/ansi.ts';
@@ -14,9 +21,10 @@ type EnvironmentCheck = (baseline: SavedResult, candidate: SavedResult) => Check
 
 interface BenchData {
   samples: number[];
-  noisy: boolean;
   /** Per-block medians, the independent experimental units. */
   blocks?: number[];
+  /** Isolation mode of the run this bench came from, for actionable skip reasons. */
+  isolation?: 'bench' | 'file';
 }
 
 type BenchCheck = (baseline: BenchData, candidate: BenchData, config: LabsConfig) => CheckResult;
@@ -26,9 +34,14 @@ type BenchCheck = (baseline: BenchData, candidate: BenchData, config: LabsConfig
 /** Max relative difference between the two runs' median clock speeds to consider them comparable. */
 const CLOCK_COMPARE_THRESHOLD = 0.05;
 
+// Run-level clock signals use only the two long calibrated readings
+// (runFreq/postFreq). The cheap 50ms per-block probes estimate the clock with
+// a different warmup and budget, so they are only ever compared against each
+// other (block-level: clock attribution and the clock-confounded gate) —
+// pooling them here would read the calibration offset as drift.
 function medianFreq(freqs: FreqSample[]): number {
   if (freqs.length === 0) return 0;
-  const all = freqs.flatMap((s) => [s.runFreq, s.postFreq, ...(s.blockFreqs ?? [])]);
+  const all = freqs.flatMap((s) => [s.runFreq, s.postFreq]);
   return median(all);
 }
 
@@ -45,7 +58,7 @@ export const checkHardwareMatch: EnvironmentCheck = (baseline, candidate) => {
 
 function freqDrift(freqs: FreqSample[]): number {
   if (freqs.length === 0) return 0;
-  const all = freqs.flatMap((s) => [s.runFreq, s.postFreq, ...(s.blockFreqs ?? [])]);
+  const all = freqs.flatMap((s) => [s.runFreq, s.postFreq]);
   const min = Math.min(...all);
   const max = Math.max(...all);
   return (max - min) / ((max + min) / 2);
@@ -122,21 +135,16 @@ export const ENVIRONMENT_CHECKS: EnvironmentCheck[] = [checkHardwareMatch];
 
 // ─── Per-bench checks ────────────────────────────────────────────────────────
 
-export const checkNotNoisy: BenchCheck = (baseline, candidate) => {
-  if (baseline.noisy && candidate.noisy)
-    return { ok: false, reason: 'noisy — measurement variance too high for a verdict in both runs' };
-  if (baseline.noisy)
-    return { ok: false, reason: 'noisy — baseline variance too high for a verdict' };
-  if (candidate.noisy)
-    return { ok: false, reason: 'noisy — candidate variance too high for a verdict' };
-  return { ok: true };
-};
-
 /**
  * Samples within one process are correlated, so fresh-process blocks are the
  * independent experimental units and verdicts require block replication on
  * both sides. Eligibility also requires enough combined allocations for the
  * exact test to reach the configured alpha.
+ *
+ * There is deliberately no noisiness gate: the exact test on block medians is
+ * already spread-aware (high spread widens the CI and lifts p), so noisy
+ * benches keep their verdicts and are annotated with their resolution in the
+ * report instead of being hidden.
  */
 const MIN_REPLICATED_BLOCKS = 2;
 
@@ -144,11 +152,17 @@ export const checkBlockReplication: BenchCheck = (baseline, candidate, config) =
   const bN = baseline.blocks?.length ?? 1;
   const cN = candidate.blocks?.length ?? 1;
   if (bN < MIN_REPLICATED_BLOCKS || cN < MIN_REPLICATED_BLOCKS) {
+    // With isolation off the runner forces single-block runs, so "re-save"
+    // would be a dead end — say what actually has to change.
+    const fix =
+      baseline.isolation === 'file' || candidate.isolation === 'file'
+        ? 'blocked sampling requires isolation; enable isolate and re-save'
+        : 're-save with blocked sampling';
     return {
       ok: false,
       reason:
         `insufficient block replication (baseline: ${bN}, candidate: ${cN}; ` +
-        `need ≥${MIN_REPLICATED_BLOCKS} per side) — re-save with blocked sampling`,
+        `need ≥${MIN_REPLICATED_BLOCKS} per side) — ${fix}`,
     };
   }
 
@@ -165,7 +179,7 @@ export const checkBlockReplication: BenchCheck = (baseline, candidate, config) =
 };
 
 /** All per-bench checks in order. Any failure skips that bench with a reason. */
-export const BENCH_CHECKS: BenchCheck[] = [checkNotNoisy, checkBlockReplication];
+export const BENCH_CHECKS: BenchCheck[] = [checkBlockReplication];
 
 // ─── Data types ──────────────────────────────────────────────────────────────
 
@@ -191,6 +205,13 @@ export interface EligibleBench {
   hl: number;
   ciLow: number;
   ciHigh: number;
+  /**
+   * Worse of the two sides' between-run resolutions (minimum detectable
+   * effect from between-block spread). Above minDelta the row is annotated
+   * noisy: verdicts still stand, but a neutral means "could not tell", not
+   * "no change".
+   */
+  resolution: number;
 }
 
 export interface SkippedBench {
@@ -233,7 +254,6 @@ function trialRuns(trial: ComparableTrial): Array<{
   name: string;
   samples: number[];
   p99: number;
-  noisy: boolean;
   blocks?: number[];
   freqs?: number[];
 }> {
@@ -243,7 +263,6 @@ function trialRuns(trial: ComparableTrial): Array<{
     name,
     samples: Array.isArray(stats?.samples) ? stats.samples : [],
     p99: typeof stats?.p99 === 'number' ? stats.p99 : 0,
-    noisy: !!stats?.noisy,
     ...(Array.isArray(stats?.blocks?.medians) ? { blocks: stats.blocks.medians } : {}),
     ...(Array.isArray(stats?.blocks?.freqs) ? { freqs: stats.blocks.freqs } : {}),
   });
@@ -260,7 +279,6 @@ function trialRuns(trial: ComparableTrial): Array<{
 interface IndexEntry {
   p99: number;
   samples: number[];
-  noisy: boolean;
   blocks?: number[];
   freqs?: number[];
 }
@@ -274,7 +292,6 @@ function buildIndex(result: SavedResult): Map<string, IndexEntry> {
         map.set(key, {
           p99: run.p99,
           samples: run.samples,
-          noisy: run.noisy,
           ...(run.blocks ? { blocks: run.blocks } : {}),
           ...(run.freqs ? { freqs: run.freqs } : {}),
         });
@@ -303,10 +320,19 @@ function benchKey(
 // ─── Clock gate ──────────────────────────────────────────────────────────────
 
 /**
+ * Median block clocks must differ by more than this before the cycles
+ * cross-check can veto a verdict. The per-block probes carry a percent or two
+ * of jitter; below this threshold a time/cycles disagreement says more about
+ * probe noise than about the clock, and skipping would eat real verdicts.
+ */
+const CLOCK_GATE_MIN_DIFF = 0.02;
+
+/**
  * Re-judges a bench in cycles instead of time and returns a skip reason when
  * the two verdicts disagree. Only applies when both sides carry a valid clock
- * probe for every block; equal clocks make the cycles verdict identical to
- * the time verdict, so the gate is inert unless the runs' clocks differed.
+ * probe for every block and the runs' median block clocks actually differ
+ * (beyond CLOCK_GATE_MIN_DIFF); with equal clocks the cycles data is just
+ * time scaled by probe jitter, so the gate stays inert.
  */
 function clockConfounded(
   base: IndexEntry,
@@ -320,6 +346,11 @@ function clockConfounded(
     blocks && freqs && freqs.length === blocks.length && freqs.every((f) => f > 0);
   if (!usable(base.blocks, bFreqs) || !usable(candidate.blocks, cFreqs)) return undefined;
 
+  const bClock = median(bFreqs!);
+  const cClock = median(cFreqs!);
+  const clockDiff = Math.abs(bClock - cClock) / ((bClock + cClock) / 2);
+  if (clockDiff <= CLOCK_GATE_MIN_DIFF) return undefined;
+
   const cycles = (blocks: number[], freqs: number[]) => blocks.map((m, i) => m * freqs[i]);
   const cyclesVerdict = classify(
     cycles(base.blocks!, bFreqs!),
@@ -330,7 +361,7 @@ function clockConfounded(
 
   return (
     `clock-confounded — time-based verdict "${timeVerdict}" but cycles-based "${cyclesVerdict}" ` +
-    `(median clocks ${median(bFreqs!).toFixed(2)} vs ${median(cFreqs!).toFixed(2)} GHz)`
+    `(median clocks ${bClock.toFixed(2)} vs ${cClock.toFixed(2)} GHz)`
   );
 }
 
@@ -399,8 +430,8 @@ export function compare(
         }
 
         const benchData = {
-          baseline: { samples: base.samples, noisy: base.noisy, blocks: base.blocks },
-          candidate: { samples: run.samples, noisy: run.noisy, blocks: run.blocks },
+          baseline: { samples: base.samples, blocks: base.blocks, isolation: baseline.isolation },
+          candidate: { samples: run.samples, blocks: run.blocks, isolation: candidate.isolation },
         };
 
         let skipReason: string | undefined;
@@ -451,6 +482,7 @@ export function compare(
           hl: time.hl,
           ciLow: time.ciLow,
           ciHigh: time.ciHigh,
+          resolution: Math.max(benchResolution(base.blocks!), benchResolution(run.blocks!)),
         });
       }
     }
@@ -576,6 +608,7 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
 
     let lastFile = '';
     let lastGroup = '';
+    let sawNoisy = false;
 
     for (const bench of eligible) {
       if (bench.key.file !== lastFile) {
@@ -602,6 +635,9 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
       const dp50Color = neutral ? DIM : bench.verdict === 'faster' ? GREEN : RED;
       const dp99Color = neutral ? DIM : deltaColor(bench.deltaP99, sig);
       const pColor = neutral ? DIM : WHITE;
+      const noisy = bench.resolution > config.minDelta;
+      if (noisy) sawNoisy = true;
+      const noisyMark = noisy ? `  ${YELLOW}⚠ ~±${(bench.resolution * 100).toFixed(0)}%${RESET}` : '';
 
       console.log(
         `  ${color}${symbol}${RESET} ${WHITE}${name}${RESET}` +
@@ -610,11 +646,21 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
           ` ${dp50Color}${formatDelta(bench.deltaP50).padStart(DELTA_COL)}${RESET}` +
           ` ${dp99Color}${formatDelta(bench.deltaP99).padStart(DELTA_COL)}${RESET}` +
           ` ${pColor}${formatP(bench.p).padStart(P_COL)}${RESET}` +
-          ` ${neutral ? DIM : WHITE}${formatCI(bench.ciLow, bench.ciHigh).padStart(CI_COL)}${RESET}`
+          ` ${neutral ? DIM : WHITE}${formatCI(bench.ciLow, bench.ciHigh).padStart(CI_COL)}${RESET}` +
+          noisyMark
       );
 
       const dist = renderDistributions(bench.baselineSamples, bench.candidateSamples, TIME_COL);
       console.log(`${' '.repeat(4 + nameCol)} ${dist.baseline} ${dist.candidate}`);
+      console.log('');
+    }
+
+    if (sawNoisy) {
+      console.log(
+        `${YELLOW}⚠${RESET} ${DIM}between-block spread limits these benches to the shown ` +
+          `resolution (above minΔ=${(config.minDelta * 100).toFixed(0)}%); a neutral there ` +
+          `means "could not tell", not "no change"${RESET}`
+      );
       console.log('');
     }
   }

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -187,7 +187,10 @@ export interface EligibleBench {
   p: number;
   d: number;
   verdict: Verdict;
-  effectiveMinDelta: number;
+  /** Hodges-Lehmann relative delta on block medians; positive means slower. */
+  hl: number;
+  ciLow: number;
+  ciHigh: number;
 }
 
 export interface SkippedBench {
@@ -232,6 +235,7 @@ function trialRuns(trial: ComparableTrial): Array<{
   p99: number;
   noisy: boolean;
   blocks?: number[];
+  freqs?: number[];
 }> {
   const alias = (trial as any).alias ?? 'anonymous';
   const runs = (trial as any).runs as Array<any> | undefined;
@@ -241,6 +245,7 @@ function trialRuns(trial: ComparableTrial): Array<{
     p99: typeof stats?.p99 === 'number' ? stats.p99 : 0,
     noisy: !!stats?.noisy,
     ...(Array.isArray(stats?.blocks?.medians) ? { blocks: stats.blocks.medians } : {}),
+    ...(Array.isArray(stats?.blocks?.freqs) ? { freqs: stats.blocks.freqs } : {}),
   });
 
   if (Array.isArray(runs) && runs.length > 0) {
@@ -257,6 +262,7 @@ interface IndexEntry {
   samples: number[];
   noisy: boolean;
   blocks?: number[];
+  freqs?: number[];
 }
 
 function buildIndex(result: SavedResult): Map<string, IndexEntry> {
@@ -270,6 +276,7 @@ function buildIndex(result: SavedResult): Map<string, IndexEntry> {
           samples: run.samples,
           noisy: run.noisy,
           ...(run.blocks ? { blocks: run.blocks } : {}),
+          ...(run.freqs ? { freqs: run.freqs } : {}),
         });
       }
     }
@@ -293,6 +300,40 @@ function benchKey(
   return { file, group: trial.groupName ?? trial.alias, name: runName };
 }
 
+// ─── Clock gate ──────────────────────────────────────────────────────────────
+
+/**
+ * Re-judges a bench in cycles instead of time and returns a skip reason when
+ * the two verdicts disagree. Only applies when both sides carry a valid clock
+ * probe for every block; equal clocks make the cycles verdict identical to
+ * the time verdict, so the gate is inert unless the runs' clocks differed.
+ */
+function clockConfounded(
+  base: IndexEntry,
+  candidate: IndexEntry,
+  timeVerdict: Verdict,
+  opts: ClassifyOptions
+): string | undefined {
+  const bFreqs = base.freqs;
+  const cFreqs = candidate.freqs;
+  const usable = (blocks?: number[], freqs?: number[]) =>
+    blocks && freqs && freqs.length === blocks.length && freqs.every((f) => f > 0);
+  if (!usable(base.blocks, bFreqs) || !usable(candidate.blocks, cFreqs)) return undefined;
+
+  const cycles = (blocks: number[], freqs: number[]) => blocks.map((m, i) => m * freqs[i]);
+  const cyclesVerdict = classify(
+    cycles(base.blocks!, bFreqs!),
+    cycles(candidate.blocks!, cFreqs!),
+    opts
+  ).verdict;
+  if (cyclesVerdict === timeVerdict) return undefined;
+
+  return (
+    `clock-confounded — time-based verdict "${timeVerdict}" but cycles-based "${cyclesVerdict}" ` +
+    `(median clocks ${median(bFreqs!).toFixed(2)} vs ${median(cFreqs!).toFixed(2)} GHz)`
+  );
+}
+
 // ─── Core comparison ─────────────────────────────────────────────────────────
 
 export function compare(
@@ -303,7 +344,6 @@ export function compare(
   const opts: ClassifyOptions = {
     alpha: config.alpha,
     minDelta: config.minDelta,
-    minEffect: config.minEffect,
   };
 
   const environmentFailures: string[] = [];
@@ -384,7 +424,17 @@ export function compare(
         // Verdicts test block medians: samples within a process are correlated,
         // so pooled samples would shrink p arbitrarily without independent
         // replication. Pooled data remains for the display columns only.
-        const { verdict, p, d, effectiveMinDelta } = classify(base.blocks!, run.blocks!, opts);
+        const time = classify(base.blocks!, run.blocks!, opts);
+
+        // A common-mode clock difference between runs shifts every block
+        // together, which the block test cannot see. Judging the same data in
+        // cycles (median × its block's clock) covers the opposite assumption:
+        // the verdict must hold whether the bench is clock-bound or not.
+        const clockGate = clockConfounded(base, run, time.verdict, opts);
+        if (clockGate !== undefined) {
+          benches.push({ kind: 'skipped', key: key_, reason: clockGate });
+          continue;
+        }
 
         benches.push({
           kind: 'eligible',
@@ -395,10 +445,12 @@ export function compare(
           candidateSamples: run.samples,
           deltaP50,
           deltaP99,
-          p,
-          d,
-          verdict,
-          effectiveMinDelta,
+          p: time.p,
+          d: time.d,
+          verdict: time.verdict,
+          hl: time.hl,
+          ciLow: time.ciLow,
+          ciHigh: time.ciHigh,
         });
       }
     }
@@ -438,7 +490,7 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
   );
   console.log(`${DIM}${result.hardware.cpu ?? 'unknown CPU'}${RESET}`);
   console.log(
-    `${DIM}Mann-Whitney U on block medians  α=${config.alpha}  minΔ=${(config.minDelta * 100).toFixed(0)}%  cliff's d≥${config.minEffect}${RESET}\n`
+    `${DIM}Mann-Whitney U on block medians  α=${config.alpha}  minΔ=${(config.minDelta * 100).toFixed(0)}%${RESET}\n`
   );
 
   if (result.environmentWarnings.length > 0) {
@@ -485,12 +537,13 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
   const TIME_COL = 10;
   const DELTA_COL = 7;
   const P_COL = 5;
-  const THRESH_COL = 5;
+  const CI_COL = 14;
 
   const truncate = (s: string) =>
     s.length > nameCol ? s.slice(0, nameCol - 1) + '…' : s.padEnd(nameCol);
 
-  const formatThreshold = (v: number) => `±${(v * 100).toFixed(0)}%`;
+  const pct = (v: number) => `${v > 0 ? '+' : ''}${(v * 100).toFixed(1)}`;
+  const formatCI = (low: number, high: number) => `${pct(low)}..${pct(high)}%`;
 
   // ── Eligible bench table ─────────────────────────────────────────────────
 
@@ -509,7 +562,7 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
       1 +
       P_COL +
       1 +
-      THRESH_COL;
+      CI_COL;
     const header =
       `${GRAY}${'  ' + 'bench'.padEnd(nameCol + 2)}` +
       ` ${'baseline'.padStart(TIME_COL)}` +
@@ -517,7 +570,7 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
       ` ${'Δp50'.padStart(DELTA_COL)}` +
       ` ${'Δp99'.padStart(DELTA_COL)}` +
       ` ${'p'.padStart(P_COL)}` +
-      ` ${'±Δ'.padStart(THRESH_COL)}` +
+      ` ${`Δ ${(100 * (1 - config.alpha)).toFixed(0)}% CI`.padStart(CI_COL)}` +
       `${RESET}`;
     const divider = `${GRAY}${'-'.repeat(totalWidth)}${RESET}`;
 
@@ -557,7 +610,7 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
           ` ${dp50Color}${formatDelta(bench.deltaP50).padStart(DELTA_COL)}${RESET}` +
           ` ${dp99Color}${formatDelta(bench.deltaP99).padStart(DELTA_COL)}${RESET}` +
           ` ${pColor}${formatP(bench.p).padStart(P_COL)}${RESET}` +
-          ` ${DIM}${formatThreshold(bench.effectiveMinDelta).padStart(THRESH_COL)}${RESET}`
+          ` ${neutral ? DIM : WHITE}${formatCI(bench.ciLow, bench.ciHigh).padStart(CI_COL)}${RESET}`
       );
 
       const dist = renderDistributions(bench.baselineSamples, bench.candidateSamples, TIME_COL);

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -637,7 +637,7 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
       const pColor = neutral ? DIM : WHITE;
       const noisy = bench.resolution > config.minDelta;
       if (noisy) sawNoisy = true;
-      const noisyMark = noisy ? `  ${YELLOW}⚠ ~±${(bench.resolution * 100).toFixed(0)}%${RESET}` : '';
+      const noisyLabel = `⚠ ~±${(bench.resolution * 100).toFixed(0)}%`;
 
       console.log(
         `  ${color}${symbol}${RESET} ${WHITE}${name}${RESET}` +
@@ -646,20 +646,21 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
           ` ${dp50Color}${formatDelta(bench.deltaP50).padStart(DELTA_COL)}${RESET}` +
           ` ${dp99Color}${formatDelta(bench.deltaP99).padStart(DELTA_COL)}${RESET}` +
           ` ${pColor}${formatP(bench.p).padStart(P_COL)}${RESET}` +
-          ` ${neutral ? DIM : WHITE}${formatCI(bench.ciLow, bench.ciHigh).padStart(CI_COL)}${RESET}` +
-          noisyMark
+          ` ${neutral ? DIM : WHITE}${formatCI(bench.ciLow, bench.ciHigh).padStart(CI_COL)}${RESET}`
       );
 
       const dist = renderDistributions(bench.baselineSamples, bench.candidateSamples, TIME_COL);
-      console.log(`${' '.repeat(4 + nameCol)} ${dist.baseline} ${dist.candidate}`);
+      const noisyMark = noisy
+        ? `${' '.repeat(1 + DELTA_COL + 1 + DELTA_COL + 1 + P_COL + 1)}` +
+          `${YELLOW}${noisyLabel.padStart(CI_COL)}${RESET}`
+        : '';
+      console.log(`${' '.repeat(4 + nameCol)} ${dist.baseline} ${dist.candidate}${noisyMark}`);
       console.log('');
     }
 
     if (sawNoisy) {
       console.log(
-        `${YELLOW}⚠${RESET} ${DIM}between-block spread limits these benches to the shown ` +
-          `resolution (above minΔ=${(config.minDelta * 100).toFixed(0)}%); a neutral there ` +
-          `means "could not tell", not "no change"${RESET}`
+        `${YELLOW}⚠${RESET} ${DIM}Neutral means inconclusive at the shown resolution.${RESET}`
       );
       console.log('');
     }

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,6 +1,6 @@
 import type { LabsConfig } from './config.ts';
 import { renderDistributions } from './histogram.ts';
-import { type ClassifyOptions, type Verdict, classify, median } from './stats.ts';
+import { type ClassifyOptions, type Verdict, classify, median, minMannWhitneyP } from './stats.ts';
 import { type FreqSample, type GitInfo, type SavedResult, isEnvironmentStable } from './store.ts';
 import { gitHint } from './cli/utils.ts';
 import { BOLD, CYAN, DARK_GRAY, DIM, GRAY, GREEN, RED, RESET, WHITE, YELLOW } from './utils/ansi.ts';
@@ -19,7 +19,7 @@ interface BenchData {
   blocks?: number[];
 }
 
-type BenchCheck = (baseline: BenchData, candidate: BenchData) => CheckResult;
+type BenchCheck = (baseline: BenchData, candidate: BenchData, config: LabsConfig) => CheckResult;
 
 // ─── Environment checks ──────────────────────────────────────────────────────
 
@@ -107,7 +107,7 @@ export const warnBlocksMismatch: EnvironmentWarning = (baseline, candidate) => {
   if (b === c) return [];
   return [
     `runs used different block counts (baseline: ${b}, candidate: ${c}) — ` +
-      `benches without ≥${MIN_BLOCKS} blocks on both sides are skipped`,
+      `eligibility uses the actual counts and configured significance level`,
   ];
 };
 
@@ -135,20 +135,32 @@ export const checkNotNoisy: BenchCheck = (baseline, candidate) => {
 /**
  * Samples within one process are correlated, so fresh-process blocks are the
  * independent experimental units and verdicts require block replication on
- * both sides. Five per side is the smallest count where the exact
- * Mann-Whitney test can reach significance at alpha 0.05 (min p = 2/252).
+ * both sides. Eligibility also requires enough combined allocations for the
+ * exact test to reach the configured alpha.
  */
-const MIN_BLOCKS = 5;
+const MIN_REPLICATED_BLOCKS = 2;
 
-export const checkBlockReplication: BenchCheck = (baseline, candidate) => {
+export const checkBlockReplication: BenchCheck = (baseline, candidate, config) => {
   const bN = baseline.blocks?.length ?? 1;
   const cN = candidate.blocks?.length ?? 1;
-  if (bN >= MIN_BLOCKS && cN >= MIN_BLOCKS) return { ok: true };
+  if (bN < MIN_REPLICATED_BLOCKS || cN < MIN_REPLICATED_BLOCKS) {
+    return {
+      ok: false,
+      reason:
+        `insufficient block replication (baseline: ${bN}, candidate: ${cN}; ` +
+        `need ≥${MIN_REPLICATED_BLOCKS} per side) — re-save with blocked sampling`,
+    };
+  }
+
+  const alpha = config.alpha ?? 0.05;
+  const minP = minMannWhitneyP(bN, cN);
+  if (minP <= alpha) return { ok: true };
   return {
     ok: false,
     reason:
-      `insufficient block replication (baseline: ${bN}, candidate: ${cN}; need ≥${MIN_BLOCKS}) — ` +
-      `re-save with blocked sampling`,
+      `block counts cannot reach α=${alpha} ` +
+      `(baseline: ${bN}, candidate: ${cN}; smallest attainable p=${minP.toPrecision(2)}) — ` +
+      `add blocks`,
   };
 };
 
@@ -241,7 +253,6 @@ function trialRuns(trial: ComparableTrial): Array<{
 // ─── Index helpers ───────────────────────────────────────────────────────────
 
 interface IndexEntry {
-  median: number;
   p99: number;
   samples: number[];
   noisy: boolean;
@@ -255,7 +266,6 @@ function buildIndex(result: SavedResult): Map<string, IndexEntry> {
       for (const run of trialRuns(trial)) {
         const key = `${f.file}\0${trial.groupName ?? ''}\0${run.name}`;
         map.set(key, {
-          median: run.samples.length > 0 ? median(run.samples) : 0,
           p99: run.p99,
           samples: run.samples,
           noisy: run.noisy,
@@ -355,7 +365,7 @@ export function compare(
 
         let skipReason: string | undefined;
         for (const check of BENCH_CHECKS) {
-          const result = check(benchData.baseline, benchData.candidate);
+          const result = check(benchData.baseline, benchData.candidate, config);
           if (!result.ok) {
             skipReason = result.reason;
             break;
@@ -367,8 +377,9 @@ export function compare(
           continue;
         }
 
-        const candidateMedian = median(run.samples);
-        const deltaP50 = base.median > 0 ? (candidateMedian - base.median) / base.median : 0;
+        const baselineMedian = median(base.blocks!);
+        const candidateMedian = median(run.blocks!);
+        const deltaP50 = baselineMedian > 0 ? (candidateMedian - baselineMedian) / baselineMedian : 0;
         const deltaP99 = base.p99 > 0 ? (run.p99 - base.p99) / base.p99 : 0;
         // Verdicts test block medians: samples within a process are correlated,
         // so pooled samples would shrink p arbitrarily without independent
@@ -378,7 +389,7 @@ export function compare(
         benches.push({
           kind: 'eligible',
           key: key_,
-          baselineP50: base.median,
+          baselineP50: baselineMedian,
           candidateP50: candidateMedian,
           baselineSamples: base.samples,
           candidateSamples: run.samples,

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -3,8 +3,8 @@ import { renderDistributions } from './histogram.ts';
 import {
   type ClassifyOptions,
   type Verdict,
-  benchResolution,
   classify,
+  comparisonResolution,
   median,
   minMannWhitneyP,
 } from './stats.ts';
@@ -21,8 +21,8 @@ type EnvironmentCheck = (baseline: SavedResult, candidate: SavedResult) => Check
 
 interface BenchData {
   samples: number[];
-  /** Per-block medians, the independent experimental units. */
-  blocks?: number[];
+  /** Fresh-run medians, the independent experimental units. */
+  runMedians?: number[];
   /** Isolation mode of the run this bench came from, for actionable skip reasons. */
   isolation?: 'bench' | 'file';
 }
@@ -114,7 +114,7 @@ export const warnIsolationMismatch: EnvironmentWarning = (baseline, candidate) =
   ];
 };
 
-export const warnBlocksMismatch: EnvironmentWarning = (baseline, candidate) => {
+export const warnFreshRunCountMismatch: EnvironmentWarning = (baseline, candidate) => {
   const b = baseline.blocks ?? 1;
   const c = candidate.blocks ?? 1;
   if (b === c) return [];
@@ -127,7 +127,7 @@ export const warnBlocksMismatch: EnvironmentWarning = (baseline, candidate) => {
 export const ENVIRONMENT_WARNINGS: EnvironmentWarning[] = [
   warnClockDrift,
   warnIsolationMismatch,
-  warnBlocksMismatch,
+  warnFreshRunCountMismatch,
 ];
 
 /** All environment checks in order. Any failure blocks the entire comparison. */
@@ -141,17 +141,17 @@ export const ENVIRONMENT_CHECKS: EnvironmentCheck[] = [checkHardwareMatch];
  * both sides. Eligibility also requires enough combined allocations for the
  * exact test to reach the configured alpha.
  *
- * There is deliberately no noisiness gate: the exact test on block medians is
- * already spread-aware (high spread widens the CI and lifts p), so noisy
- * benches keep their verdicts and are annotated with their resolution in the
- * report instead of being hidden.
+ * There is deliberately no run-consistency gate: the exact test on block
+ * medians is already spread-aware (high spread widens the CI and lifts p), so
+ * benchmarks with limited resolution keep their verdicts and are annotated
+ * instead of being hidden.
  */
-const MIN_REPLICATED_BLOCKS = 2;
+const MIN_FRESH_RUNS = 2;
 
-export const checkBlockReplication: BenchCheck = (baseline, candidate, config) => {
-  const bN = baseline.blocks?.length ?? 1;
-  const cN = candidate.blocks?.length ?? 1;
-  if (bN < MIN_REPLICATED_BLOCKS || cN < MIN_REPLICATED_BLOCKS) {
+export const checkFreshRunReplication: BenchCheck = (baseline, candidate, config) => {
+  const bN = baseline.runMedians?.length ?? 1;
+  const cN = candidate.runMedians?.length ?? 1;
+  if (bN < MIN_FRESH_RUNS || cN < MIN_FRESH_RUNS) {
     // With isolation off the runner forces single-block runs, so "re-save"
     // would be a dead end — say what actually has to change.
     const fix =
@@ -162,7 +162,7 @@ export const checkBlockReplication: BenchCheck = (baseline, candidate, config) =
       ok: false,
       reason:
         `insufficient block replication (baseline: ${bN}, candidate: ${cN}; ` +
-        `need ≥${MIN_REPLICATED_BLOCKS} per side) — ${fix}`,
+        `need ≥${MIN_FRESH_RUNS} per side) — ${fix}`,
     };
   }
 
@@ -179,7 +179,7 @@ export const checkBlockReplication: BenchCheck = (baseline, candidate, config) =
 };
 
 /** All per-bench checks in order. Any failure skips that bench with a reason. */
-export const BENCH_CHECKS: BenchCheck[] = [checkBlockReplication];
+export const BENCH_CHECKS: BenchCheck[] = [checkFreshRunReplication];
 
 // ─── Data types ──────────────────────────────────────────────────────────────
 
@@ -207,11 +207,11 @@ export interface EligibleBench {
   ciHigh: number;
   /**
    * Worse of the two sides' between-run resolutions (minimum detectable
-   * effect from between-block spread). Above minDelta the row is annotated
-   * noisy: verdicts still stand, but a neutral means "could not tell", not
-   * "no change".
+   * effect from fresh-run median spread). Above minDelta the row is annotated
+   * with limited resolution: verdicts still stand, but a neutral means "could
+   * not tell", not "no change".
    */
-  resolution: number;
+  comparisonResolution: number;
 }
 
 export interface SkippedBench {
@@ -244,8 +244,8 @@ export interface CompareResult {
 type LegacyTrial = {
   alias?: string;
   groupName?: string;
-  stats?: { samples?: number[]; noisy?: boolean; p99?: number };
-  runs?: Array<{ name?: string; stats?: { samples?: number[]; noisy?: boolean; p99?: number } }>;
+  stats?: { samples?: number[]; p99?: number };
+  runs?: Array<{ name?: string; stats?: { samples?: number[]; p99?: number } }>;
 };
 
 type ComparableTrial = SavedResult['files'][number]['benchmarks'][number] | LegacyTrial;
@@ -254,8 +254,8 @@ function trialRuns(trial: ComparableTrial): Array<{
   name: string;
   samples: number[];
   p99: number;
-  blocks?: number[];
-  freqs?: number[];
+  runMedians?: number[];
+  calibrationRates?: number[];
 }> {
   const alias = (trial as any).alias ?? 'anonymous';
   const runs = (trial as any).runs as Array<any> | undefined;
@@ -263,8 +263,8 @@ function trialRuns(trial: ComparableTrial): Array<{
     name,
     samples: Array.isArray(stats?.samples) ? stats.samples : [],
     p99: typeof stats?.p99 === 'number' ? stats.p99 : 0,
-    ...(Array.isArray(stats?.blocks?.medians) ? { blocks: stats.blocks.medians } : {}),
-    ...(Array.isArray(stats?.blocks?.freqs) ? { freqs: stats.blocks.freqs } : {}),
+    ...(Array.isArray(stats?.blocks?.medians) ? { runMedians: stats.blocks.medians } : {}),
+    ...(Array.isArray(stats?.blocks?.freqs) ? { calibrationRates: stats.blocks.freqs } : {}),
   });
 
   if (Array.isArray(runs) && runs.length > 0) {
@@ -279,8 +279,8 @@ function trialRuns(trial: ComparableTrial): Array<{
 interface IndexEntry {
   p99: number;
   samples: number[];
-  blocks?: number[];
-  freqs?: number[];
+  runMedians?: number[];
+  calibrationRates?: number[];
 }
 
 function buildIndex(result: SavedResult): Map<string, IndexEntry> {
@@ -292,8 +292,8 @@ function buildIndex(result: SavedResult): Map<string, IndexEntry> {
         map.set(key, {
           p99: run.p99,
           samples: run.samples,
-          ...(run.blocks ? { blocks: run.blocks } : {}),
-          ...(run.freqs ? { freqs: run.freqs } : {}),
+          ...(run.runMedians ? { runMedians: run.runMedians } : {}),
+          ...(run.calibrationRates ? { calibrationRates: run.calibrationRates } : {}),
         });
       }
     }
@@ -320,49 +320,53 @@ function benchKey(
 // ─── Clock gate ──────────────────────────────────────────────────────────────
 
 /**
- * Median block clocks must differ by more than this before the cycles
- * cross-check can veto a verdict. The per-block probes carry a percent or two
- * of jitter; below this threshold a time/cycles disagreement says more about
- * probe noise than about the clock, and skipping would eat real verdicts.
+ * Median calibration rates must differ by more than this before normalization
+ * can veto a verdict. The short probes carry a percent or two of variation;
+ * below this threshold a disagreement says more about the probe than machine
+ * state, and skipping would eat real verdicts.
  */
-const CLOCK_GATE_MIN_DIFF = 0.02;
+const CALIBRATION_GATE_MIN_DIFF = 0.02;
 const CLOCK_CONFOUNDED_PREFIX = 'clock-confounded — ';
 
 /**
- * Re-judges a bench in cycles instead of time and returns a skip reason when
- * the two verdicts disagree. Only applies when both sides carry a valid clock
- * probe for every block and the runs' median block clocks actually differ
- * (beyond CLOCK_GATE_MIN_DIFF); with equal clocks the cycles data is just
- * time scaled by probe jitter, so the gate stays inert.
+ * Re-judges a benchmark after calibration-rate normalization and returns a
+ * skip reason when the verdicts disagree. Only applies when both sides carry
+ * a valid probe for every run and their median rates differ beyond the jitter
+ * guard. With similar rates, normalization would mostly add probe variation.
  */
-function clockConfounded(
+function calibrationSensitive(
   base: IndexEntry,
   candidate: IndexEntry,
   timeVerdict: Verdict,
   opts: ClassifyOptions
 ): string | undefined {
-  const bFreqs = base.freqs;
-  const cFreqs = candidate.freqs;
-  const usable = (blocks?: number[], freqs?: number[]) =>
-    blocks && freqs && freqs.length === blocks.length && freqs.every((f) => f > 0);
-  if (!usable(base.blocks, bFreqs) || !usable(candidate.blocks, cFreqs)) return undefined;
+  const baselineRates = base.calibrationRates;
+  const candidateRates = candidate.calibrationRates;
+  const usable = (runMedians?: number[], calibrationRates?: number[]) =>
+    runMedians &&
+    calibrationRates &&
+    calibrationRates.length === runMedians.length &&
+    calibrationRates.every((rate) => rate > 0);
+  if (!usable(base.runMedians, baselineRates) || !usable(candidate.runMedians, candidateRates))
+    return undefined;
 
-  const bClock = median(bFreqs!);
-  const cClock = median(cFreqs!);
-  const clockDiff = Math.abs(bClock - cClock) / ((bClock + cClock) / 2);
-  if (clockDiff <= CLOCK_GATE_MIN_DIFF) return undefined;
+  const baselineRate = median(baselineRates!);
+  const candidateRate = median(candidateRates!);
+  const rateDiff = Math.abs(baselineRate - candidateRate) / ((baselineRate + candidateRate) / 2);
+  if (rateDiff <= CALIBRATION_GATE_MIN_DIFF) return undefined;
 
-  const cycles = (blocks: number[], freqs: number[]) => blocks.map((m, i) => m * freqs[i]);
-  const cyclesVerdict = classify(
-    cycles(base.blocks!, bFreqs!),
-    cycles(candidate.blocks!, cFreqs!),
+  const normalizedTimes = (runMedians: number[], calibrationRates: number[]) =>
+    runMedians.map((runMedian, i) => runMedian * calibrationRates[i]);
+  const normalizedVerdict = classify(
+    normalizedTimes(base.runMedians!, baselineRates!),
+    normalizedTimes(candidate.runMedians!, candidateRates!),
     opts
   ).verdict;
-  if (cyclesVerdict === timeVerdict) return undefined;
+  if (normalizedVerdict === timeVerdict) return undefined;
 
   return (
-    `${CLOCK_CONFOUNDED_PREFIX}${timeVerdict}→${cyclesVerdict} · ` +
-    `${bClock.toFixed(2)}→${cClock.toFixed(2)}`
+    `${CLOCK_CONFOUNDED_PREFIX}${timeVerdict}→${normalizedVerdict} · ` +
+    `${baselineRate.toFixed(2)}→${candidateRate.toFixed(2)}`
   );
 }
 
@@ -431,8 +435,16 @@ export function compare(
         }
 
         const benchData = {
-          baseline: { samples: base.samples, blocks: base.blocks, isolation: baseline.isolation },
-          candidate: { samples: run.samples, blocks: run.blocks, isolation: candidate.isolation },
+          baseline: {
+            samples: base.samples,
+            runMedians: base.runMedians,
+            isolation: baseline.isolation,
+          },
+          candidate: {
+            samples: run.samples,
+            runMedians: run.runMedians,
+            isolation: candidate.isolation,
+          },
         };
 
         let skipReason: string | undefined;
@@ -449,22 +461,21 @@ export function compare(
           continue;
         }
 
-        const baselineMedian = median(base.blocks!);
-        const candidateMedian = median(run.blocks!);
+        const baselineMedian = median(base.runMedians!);
+        const candidateMedian = median(run.runMedians!);
         const deltaP50 = baselineMedian > 0 ? (candidateMedian - baselineMedian) / baselineMedian : 0;
         const deltaP99 = base.p99 > 0 ? (run.p99 - base.p99) / base.p99 : 0;
-        // Verdicts test block medians: samples within a process are correlated,
+        // Verdicts test fresh-run medians: samples within a process are correlated,
         // so pooled samples would shrink p arbitrarily without independent
         // replication. Pooled data remains for the display columns only.
-        const time = classify(base.blocks!, run.blocks!, opts);
+        const time = classify(base.runMedians!, run.runMedians!, opts);
 
-        // A common-mode clock difference between runs shifts every block
-        // together, which the block test cannot see. Judging the same data in
-        // cycles (median × its block's clock) covers the opposite assumption:
-        // the verdict must hold whether the bench is clock-bound or not.
-        const clockGate = clockConfounded(base, run, time.verdict, opts);
-        if (clockGate !== undefined) {
-          benches.push({ kind: 'skipped', key: key_, reason: clockGate });
+        // A common-mode machine-speed difference shifts every run together,
+        // which the rank test cannot see. Require the verdict to survive
+        // normalization by each run's software calibration rate.
+        const calibrationGate = calibrationSensitive(base, run, time.verdict, opts);
+        if (calibrationGate !== undefined) {
+          benches.push({ kind: 'skipped', key: key_, reason: calibrationGate });
           continue;
         }
 
@@ -483,7 +494,10 @@ export function compare(
           hl: time.hl,
           ciLow: time.ciLow,
           ciHigh: time.ciHigh,
-          resolution: Math.max(benchResolution(base.blocks!), benchResolution(run.blocks!)),
+          comparisonResolution: Math.max(
+            comparisonResolution(base.runMedians!),
+            comparisonResolution(run.runMedians!)
+          ),
         });
       }
     }
@@ -609,7 +623,7 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
 
     let lastFile = '';
     let lastGroup = '';
-    let sawNoisy = false;
+    let sawLimitedResolution = false;
 
     for (const bench of eligible) {
       if (bench.key.file !== lastFile) {
@@ -636,9 +650,9 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
       const dp50Color = neutral ? DIM : bench.verdict === 'faster' ? GREEN : RED;
       const dp99Color = neutral ? DIM : deltaColor(bench.deltaP99, sig);
       const pColor = neutral ? DIM : WHITE;
-      const noisy = bench.resolution > config.minDelta;
-      if (noisy) sawNoisy = true;
-      const noisyLabel = `⚠ ~±${(bench.resolution * 100).toFixed(0)}%`;
+      const hasLimitedResolution = bench.comparisonResolution > config.minDelta;
+      if (hasLimitedResolution) sawLimitedResolution = true;
+      const resolutionLabel = `⚠ ~±${(bench.comparisonResolution * 100).toFixed(0)}%`;
 
       console.log(
         `  ${color}${symbol}${RESET} ${WHITE}${name}${RESET}` +
@@ -651,15 +665,15 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
       );
 
       const dist = renderDistributions(bench.baselineSamples, bench.candidateSamples, TIME_COL);
-      const noisyMark = noisy
+      const resolutionMark = hasLimitedResolution
         ? `${' '.repeat(1 + DELTA_COL + 1 + DELTA_COL + 1 + P_COL + 1)}` +
-          `${YELLOW}${noisyLabel.padStart(CI_COL)}${RESET}`
+          `${YELLOW}${resolutionLabel.padStart(CI_COL)}${RESET}`
         : '';
-      console.log(`${' '.repeat(4 + nameCol)} ${dist.baseline} ${dist.candidate}${noisyMark}`);
+      console.log(`${' '.repeat(4 + nameCol)} ${dist.baseline} ${dist.candidate}${resolutionMark}`);
       console.log('');
     }
 
-    if (sawNoisy) {
+    if (sawLimitedResolution) {
       console.log(
         `${YELLOW}⚠ Limited resolution:${RESET} ${DIM}Neutral results are inconclusive at the shown resolution.${RESET}`
       );
@@ -671,12 +685,14 @@ export function printCompareReport(result: CompareResult, config: LabsConfig): v
 
   if (skipped.length > 0) {
     console.log(`\n${YELLOW}skipped (${skipped.length})${RESET}`);
-    const clockConfounded = skipped.filter((b) => b.reason.startsWith(CLOCK_CONFOUNDED_PREFIX));
+    const calibrationSensitiveSkips = skipped.filter((b) =>
+      b.reason.startsWith(CLOCK_CONFOUNDED_PREFIX)
+    );
     const otherSkipped = skipped.filter((b) => !b.reason.startsWith(CLOCK_CONFOUNDED_PREFIX));
 
-    if (clockConfounded.length > 0) {
+    if (calibrationSensitiveSkips.length > 0) {
       console.log(`  ${YELLOW}clock-confounded${RESET}`);
-      for (const b of clockConfounded) {
+      for (const b of calibrationSensitiveSkips) {
         const label = truncate(b.key.name || b.key.group || 'anonymous');
         const detail = b.reason.slice(CLOCK_CONFOUNDED_PREFIX.length);
         console.log(`  ${DIM}· ${label}${RESET}  ${YELLOW}${detail}${RESET}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export interface LabsConfig {
    * minCpuTime + minSamples stopping. @default true
    */
   adaptive?: boolean | number;
-  /** Maximum CPU time budget in seconds for adaptive sampling. If hit before convergence, the benchmark is flagged `noisy`. @default 5 */
+  /** Maximum CPU time budget in seconds for adaptive sampling. If hit before convergence, samples are reported as unstable. @default 5 */
   maxCpuTime?: number;
   /** Mann-Whitney U significance level. @default 0.05 */
   alpha: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,13 +23,8 @@ export interface LabsConfig {
   maxCpuTime?: number;
   /** Mann-Whitney U significance level. @default 0.05 */
   alpha: number;
-  /** Minimum absolute Δp50 required to flag a verdict. Filters environmental noise on identical code. @default 0.05 */
+  /** Minimum |Hodges-Lehmann delta| required to flag a verdict. Filters environmental noise on identical code. @default 0.05 */
   minDelta: number;
-  /**
-   * @deprecated Unused. On block medians Cliff's d is a linear transform of
-   * the U statistic already behind the p-value, so the alpha gate subsumes it.
-   */
-  minEffect: number;
   /**
    * Whether each bench runs in a fresh worker process. Disable for suites that
    * require shared process state or have expensive module setup. @default true
@@ -55,7 +50,6 @@ export function defineConfig(config: Partial<LabsConfig> & Pick<LabsConfig, 'ben
     maxCpuTime: 5,
     alpha: 0.05,
     minDelta: 0.05,
-    minEffect: 0.474,
     isolate: true,
     blocks: 8,
     ...config,

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,13 @@ export interface LabsConfig {
    * require shared process state or have expensive module setup. @default true
    */
   isolate?: boolean;
+  /**
+   * Fresh-process blocks per bench for saved runs. Each block is a new V8, so
+   * between-block spread captures JIT nondeterminism and environment drift
+   * that a single process hides. Requires isolate. `bench run` always uses a
+   * single block. @default 8
+   */
+  blocks?: number;
 }
 
 export function defineConfig(config: Partial<LabsConfig> & Pick<LabsConfig, 'benchDir'>): LabsConfig {
@@ -47,6 +54,7 @@ export function defineConfig(config: Partial<LabsConfig> & Pick<LabsConfig, 'ben
     minDelta: 0.05,
     minEffect: 0.474,
     isolate: true,
+    blocks: 8,
     ...config,
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,10 @@ export interface LabsConfig {
   alpha: number;
   /** Minimum absolute Δp50 required to flag a verdict. Filters environmental noise on identical code. @default 0.05 */
   minDelta: number;
-  /** Minimum |Cliff's d| required to flag a verdict. Filters noise on high-variance benches where distributions overlap despite a median shift. @default 0.474 */
+  /**
+   * @deprecated Unused. On block medians Cliff's d is a linear transform of
+   * the U statistic already behind the p-value, so the alpha gate subsumes it.
+   */
   minEffect: number;
   /**
    * Whether each bench runs in a fresh worker process. Disable for suites that

--- a/src/report.ts
+++ b/src/report.ts
@@ -51,7 +51,7 @@ export function printReportBox(
 
     if (drift > 0.05) {
       lines.push(
-        `${YELLOW}⚠ CPU unstable${RESET}  ${rangeStr}  ${DIM}(${(drift * 100).toFixed(1)}% drift)${RESET}`
+        `${YELLOW}⚠ Unstable clock:${RESET} ${DIM}Readings ranged ${rangeStr} (${(drift * 100).toFixed(1)}% drift).${RESET}`
       );
       if (cpu && /apple/i.test(cpu)) {
         lines.push(`  ${DIM}Apple Silicon does not support CPU controls.${RESET}`);
@@ -62,43 +62,52 @@ export function printReportBox(
         );
       }
     } else {
-      lines.push(`${GREEN}✔ CPU stable${RESET}  ${DIM}${rangeStr}${RESET}`);
+      lines.push(`${GREEN}✔ Stable clock:${RESET} ${DIM}Readings ranged ${rangeStr}.${RESET}`);
     }
   }
 
   if (envData.length > 0) lines.push('');
 
+  let hasBlockSummary = false;
   if (blockInfo && blockInfo.blocks > 1 && blockInfo.spreads.length > 0) {
+    hasBlockSummary = true;
     const spread = median(blockInfo.spreads);
     const mde = minDetectableEffect(spread, blockInfo.blocks);
     const spreadStr = `±${(spread * 100).toFixed(1)}%`;
     // Same rule the readers use to derive per-bench noisiness, so the two agree
     const noisy = mde > blockInfo.minDelta;
     lines.push(
-      `${noisy ? YELLOW + '⚠' : GREEN + '✔'} between-block spread ${spreadStr}${RESET}  ${DIM}(${blockInfo.blocks} blocks/bench)${RESET}`
+      noisy
+        ? `${YELLOW}⚠ Inconsistent runs:${RESET} ${DIM}Median timings changed across fresh runs suggesting an unstable machine.${RESET}`
+        : `${GREEN}✔ Consistent runs:${RESET} ${DIM}Median timings remained stable across fresh runs.${RESET}`
     );
-    lines.push(`  ${DIM}between-run resolution ~±${(mde * 100).toFixed(1)}%${RESET}`);
+    lines.push(`  ${DIM}Median spread: ${spreadStr} across ${blockInfo.blocks} fresh runs.${RESET}`);
+    lines.push(`  ${DIM}Comparison resolution: ~±${(mde * 100).toFixed(1)}%.${RESET}`);
     if (blockInfo.clockExplained && blockInfo.clockExplained.length > 0) {
       const explained = median(blockInfo.clockExplained);
-      lines.push(`  ${DIM}clock explains ~${(explained * 100).toFixed(0)}% of block spread${RESET}`);
+      lines.push(
+        `  ${DIM}Clock estimate explains ~${(explained * 100).toFixed(0)}% of run-to-run spread.${RESET}`
+      );
     }
-    lines.push('');
   }
 
   if (noisyBenches.length > 0) {
-    lines.push(`${YELLOW}⚠ (${noisyBenches.length}) noisy benches${RESET}`);
+    if (!hasBlockSummary) {
+      lines.push(
+        `${YELLOW}⚠ Unstable samples:${RESET} ${DIM}Timings did not settle suggesting non-deterministic work or runtime interference.${RESET}`
+      );
+      lines.push(`  ${DIM}Time limit: ${maxCpuTime}s.${RESET}`);
+    }
+    lines.push(`  ${DIM}Affected benchmarks (${noisyBenches.length}):${RESET}`);
     for (const bench of noisyBenches) {
       const spread =
         bench.spread !== undefined ? `  ${YELLOW}±${(bench.spread * 100).toFixed(1)}%${RESET}` : '';
-      lines.push(`  ${DIM}· ${bench.name}${RESET}${spread}`);
+      lines.push(`    ${YELLOW}⚠${RESET} ${DIM}${bench.name}${RESET}${spread}`);
     }
+  } else if (!hasBlockSummary) {
     lines.push(
-      blockInfo
-        ? `  ${DIM}Between-block spread exceeds the verdict threshold.${RESET}`
-        : `  ${DIM}Increase maxCpuTime (currently ${maxCpuTime}s) to allow convergence.${RESET}`
+      `${GREEN}✔ Stable samples:${RESET} ${DIM}Timings settled within the ${maxCpuTime}s time limit.${RESET}`
     );
-  } else {
-    lines.push(`${GREEN}✔ All measurements stable${RESET}`);
   }
 
   const PAD = 2;

--- a/src/report.ts
+++ b/src/report.ts
@@ -6,6 +6,12 @@ import type { SavedBenchmarkTrial, SavedFile, SavedResult, FreqSample } from './
 import { BLUE, BOLD, DIM, GREEN, RESET, YELLOW } from './utils/ansi.ts';
 import { visibleLength } from './utils/format.ts';
 
+export interface NoisyBench {
+  name: string;
+  /** The bench's own between-block spread, shown inline when available. */
+  spread?: number;
+}
+
 export interface BlockInfo {
   blocks: number;
   /** Per-bench relative spread of block medians. */
@@ -16,7 +22,7 @@ export interface BlockInfo {
 
 export function printReportBox(
   envData: FreqSample[],
-  noisyAliases: string[],
+  noisyBenches: NoisyBench[],
   maxCpuTime: number,
   saveMsg?: string,
   cpu?: string | null,
@@ -63,18 +69,20 @@ export function printReportBox(
     lines.push(
       `${noisy ? YELLOW + '⚠' : GREEN + '✔'} between-block spread ${spreadStr}${RESET}  ${DIM}(${blockInfo.blocks} blocks/bench)${RESET}`
     );
-    lines.push(
-      `  ${DIM}est. between-run resolution ~±${(mde * 100).toFixed(1)}% (rough guide)${RESET}`
-    );
+    lines.push(`  ${DIM}between-run resolution ~±${(mde * 100).toFixed(1)}%${RESET}`);
     lines.push('');
   }
 
-  if (noisyAliases.length > 0) {
-    lines.push(`${YELLOW}⚠ (${noisyAliases.length}) noisy benches${RESET}`);
-    for (const alias of noisyAliases) lines.push(`  ${DIM}· ${alias}${RESET}`);
+  if (noisyBenches.length > 0) {
+    lines.push(`${YELLOW}⚠ (${noisyBenches.length}) noisy benches${RESET}`);
+    for (const bench of noisyBenches) {
+      const spread =
+        bench.spread !== undefined ? `  ${YELLOW}±${(bench.spread * 100).toFixed(1)}%${RESET}` : '';
+      lines.push(`  ${DIM}· ${bench.name}${RESET}${spread}`);
+    }
     lines.push(
       blockInfo
-        ? `  ${DIM}Between-block spread exceeds the verdict threshold. Add blocks or quiet the machine.${RESET}`
+        ? `  ${DIM}Between-block spread exceeds the verdict threshold.${RESET}`
         : `  ${DIM}Increase maxCpuTime (currently ${maxCpuTime}s) to allow convergence.${RESET}`
     );
   } else {
@@ -120,12 +128,17 @@ export function replayReport(result: SavedResult, config: LabsConfig): void {
     );
   }
 
-  const noisyAliases: string[] = [];
+  const noisyBenches: NoisyBench[] = [];
   const spreads: number[] = [];
   for (const f of result.files) {
     for (const b of f.benchmarks) {
       for (const run of b.runs) {
-        if (run.stats?.noisy) noisyAliases.push(run.name || b.alias);
+        if (run.stats?.noisy) {
+          noisyBenches.push({
+            name: run.name || b.alias,
+            ...(run.stats.blocks ? { spread: blockSpread(run.stats.blocks.medians) } : {}),
+          });
+        }
         if (run.stats?.blocks) spreads.push(blockSpread(run.stats.blocks.medians));
       }
     }
@@ -133,7 +146,7 @@ export function replayReport(result: SavedResult, config: LabsConfig): void {
   const blocks = result.blocks ?? 1;
   printReportBox(
     result.environment?.freqs ?? [],
-    noisyAliases,
+    noisyBenches,
     config.maxCpuTime!,
     undefined,
     result.hardware.cpu,

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,16 +1,24 @@
 import type { LabsConfig } from './config.ts';
 import { renderMitata, type RenderedCollection } from './bench/render.ts';
 import type { Context, Stats, Trial } from './bench/types.ts';
+import { blockSpread, median, minDetectableEffect } from './stats.ts';
 import type { SavedBenchmarkTrial, SavedFile, SavedResult, FreqSample } from './store.ts';
 import { BLUE, BOLD, DIM, GREEN, RESET, YELLOW } from './utils/ansi.ts';
 import { visibleLength } from './utils/format.ts';
+
+export interface BlockInfo {
+  blocks: number;
+  /** Per-bench relative spread of block medians. */
+  spreads: number[];
+}
 
 export function printReportBox(
   envData: FreqSample[],
   noisyAliases: string[],
   maxCpuTime: number,
   saveMsg?: string,
-  cpu?: string | null
+  cpu?: string | null,
+  blockInfo?: BlockInfo
 ): void {
   const lines: string[] = [];
 
@@ -19,7 +27,7 @@ export function printReportBox(
     lines.push('');
   }
   if (envData.length > 0) {
-    const allFreqs = envData.flatMap((e) => [e.runFreq, e.postFreq]);
+    const allFreqs = envData.flatMap((e) => [e.runFreq, e.postFreq, ...(e.blockFreqs ?? [])]);
     const min = Math.min(...allFreqs);
     const max = Math.max(...allFreqs);
     const drift = (max - min) / ((max + min) / 2);
@@ -44,11 +52,27 @@ export function printReportBox(
 
   if (envData.length > 0) lines.push('');
 
+  if (blockInfo && blockInfo.blocks > 1 && blockInfo.spreads.length > 0) {
+    const spread = median(blockInfo.spreads);
+    const mde = minDetectableEffect(spread, blockInfo.blocks);
+    const spreadStr = `±${(spread * 100).toFixed(1)}%`;
+    const noisy = spread > 0.03;
+    lines.push(
+      `${noisy ? YELLOW + '⚠' : GREEN + '✔'} between-block spread ${spreadStr}${RESET}  ${DIM}(${blockInfo.blocks} blocks/bench)${RESET}`
+    );
+    lines.push(
+      `  ${DIM}machine floor: comparisons resolve deltas ≥ ±${(mde * 100).toFixed(1)}%${RESET}`
+    );
+    lines.push('');
+  }
+
   if (noisyAliases.length > 0) {
     lines.push(`${YELLOW}⚠ (${noisyAliases.length}) noisy benches${RESET}`);
     for (const alias of noisyAliases) lines.push(`  ${DIM}· ${alias}${RESET}`);
     lines.push(
-      `  ${DIM}Increase maxCpuTime (currently ${maxCpuTime}s) to allow convergence.${RESET}`
+      blockInfo
+        ? `  ${DIM}Between-block spread exceeds the verdict threshold. Add blocks or quiet the machine.${RESET}`
+        : `  ${DIM}Increase maxCpuTime (currently ${maxCpuTime}s) to allow convergence.${RESET}`
     );
   } else {
     lines.push(`${GREEN}✔ All measurements stable${RESET}`);
@@ -94,19 +118,23 @@ export function replayReport(result: SavedResult, config: LabsConfig): void {
   }
 
   const noisyAliases: string[] = [];
+  const spreads: number[] = [];
   for (const f of result.files) {
     for (const b of f.benchmarks) {
       for (const run of b.runs) {
         if (run.stats?.noisy) noisyAliases.push(run.name || b.alias);
+        if (run.stats?.blocks) spreads.push(blockSpread(run.stats.blocks.medians));
       }
     }
   }
+  const blocks = result.blocks ?? 1;
   printReportBox(
     result.environment?.freqs ?? [],
     noisyAliases,
     config.maxCpuTime!,
     undefined,
-    result.hardware.cpu
+    result.hardware.cpu,
+    blocks > 1 ? { blocks, spreads } : undefined
   );
 }
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,7 +1,7 @@
 import type { LabsConfig } from './config.ts';
 import { renderMitata, type RenderedCollection } from './bench/render.ts';
 import type { Context, Stats, Trial } from './bench/types.ts';
-import { blockSpread, median, minDetectableEffect } from './stats.ts';
+import { blockSpread, clockExplainedFraction, median, minDetectableEffect } from './stats.ts';
 import type { SavedBenchmarkTrial, SavedFile, SavedResult, FreqSample } from './store.ts';
 import { BLUE, BOLD, DIM, GREEN, RESET, YELLOW } from './utils/ansi.ts';
 import { visibleLength } from './utils/format.ts';
@@ -18,6 +18,8 @@ export interface BlockInfo {
   spreads: number[];
   /** Configured verdict threshold, so the warning agrees with the noisy flag. */
   minDelta: number;
+  /** Per-bench fraction of block spread explained by clock differences. */
+  clockExplained?: number[];
 }
 
 export function printReportBox(
@@ -70,6 +72,10 @@ export function printReportBox(
       `${noisy ? YELLOW + '⚠' : GREEN + '✔'} between-block spread ${spreadStr}${RESET}  ${DIM}(${blockInfo.blocks} blocks/bench)${RESET}`
     );
     lines.push(`  ${DIM}between-run resolution ~±${(mde * 100).toFixed(1)}%${RESET}`);
+    if (blockInfo.clockExplained && blockInfo.clockExplained.length > 0) {
+      const explained = median(blockInfo.clockExplained);
+      lines.push(`  ${DIM}clock explains ~${(explained * 100).toFixed(0)}% of block spread${RESET}`);
+    }
     lines.push('');
   }
 
@@ -130,6 +136,7 @@ export function replayReport(result: SavedResult, config: LabsConfig): void {
 
   const noisyBenches: NoisyBench[] = [];
   const spreads: number[] = [];
+  const clockExplained: number[] = [];
   for (const f of result.files) {
     for (const b of f.benchmarks) {
       for (const run of b.runs) {
@@ -139,7 +146,12 @@ export function replayReport(result: SavedResult, config: LabsConfig): void {
             ...(run.stats.blocks ? { spread: blockSpread(run.stats.blocks.medians) } : {}),
           });
         }
-        if (run.stats?.blocks) spreads.push(blockSpread(run.stats.blocks.medians));
+        if (run.stats?.blocks) {
+          spreads.push(blockSpread(run.stats.blocks.medians));
+          clockExplained.push(
+            clockExplainedFraction(run.stats.blocks.medians, run.stats.blocks.freqs)
+          );
+        }
       }
     }
   }
@@ -150,7 +162,7 @@ export function replayReport(result: SavedResult, config: LabsConfig): void {
     config.maxCpuTime!,
     undefined,
     result.hardware.cpu,
-    blocks > 1 ? { blocks, spreads, minDelta: config.minDelta } : undefined
+    blocks > 1 ? { blocks, spreads, minDelta: config.minDelta, clockExplained } : undefined
   );
 }
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,40 +1,40 @@
 import type { LabsConfig } from './config.ts';
 import { renderMitata, type RenderedCollection } from './bench/render.ts';
-import type { Context, Stats, Trial } from './bench/types.ts';
+import { hasUnstableSamples, type Context, type Stats, type Trial } from './bench/types.ts';
 import {
-  benchResolution,
-  blockSpread,
-  clockExplainedFraction,
+  calibrationExplainedFraction,
+  comparisonResolution,
   median,
   minDetectableEffect,
+  runMedianSpread,
 } from './stats.ts';
 import type { SavedBenchmarkTrial, SavedFile, SavedResult, FreqSample } from './store.ts';
 import { BLUE, BOLD, DIM, GREEN, RESET, YELLOW } from './utils/ansi.ts';
 import { visibleLength } from './utils/format.ts';
 
-export interface NoisyBench {
+export interface StabilityAffectedBenchmark {
   name: string;
-  /** The bench's own between-block spread, shown inline when available. */
-  spread?: number;
+  /** This benchmark's fresh-run median spread, shown inline when available. */
+  runMedianSpread?: number;
 }
 
-export interface BlockInfo {
-  blocks: number;
-  /** Per-bench relative spread of block medians. */
-  spreads: number[];
-  /** Configured verdict threshold, so the warning agrees with the noisy flag. */
+export interface RunConsistencyInfo {
+  freshRuns: number;
+  /** Per-benchmark relative spread of fresh-run medians. */
+  medianSpreads: number[];
+  /** Configured verdict threshold used to identify inconsistent runs. */
   minDelta: number;
-  /** Per-bench fraction of block spread explained by clock differences. */
-  clockExplained?: number[];
+  /** Per-benchmark fraction of fresh-run spread explained by calibration-rate differences. */
+  calibrationExplainedFractions?: number[];
 }
 
 export function printReportBox(
   envData: FreqSample[],
-  noisyBenches: NoisyBench[],
+  affectedBenchmarks: StabilityAffectedBenchmark[],
   maxCpuTime: number,
   saveMsg?: string,
   cpu?: string | null,
-  blockInfo?: BlockInfo
+  runConsistency?: RunConsistencyInfo
 ): void {
   const lines: string[] = [];
 
@@ -68,43 +68,50 @@ export function printReportBox(
 
   if (envData.length > 0) lines.push('');
 
-  let hasBlockSummary = false;
-  if (blockInfo && blockInfo.blocks > 1 && blockInfo.spreads.length > 0) {
-    hasBlockSummary = true;
-    const spread = median(blockInfo.spreads);
-    const mde = minDetectableEffect(spread, blockInfo.blocks);
+  let hasRunConsistencySummary = false;
+  if (runConsistency && runConsistency.freshRuns > 1 && runConsistency.medianSpreads.length > 0) {
+    hasRunConsistencySummary = true;
+    const spread = median(runConsistency.medianSpreads);
+    const resolution = minDetectableEffect(spread, runConsistency.freshRuns);
     const spreadStr = `±${(spread * 100).toFixed(1)}%`;
-    // Same rule the readers use to derive per-bench noisiness, so the two agree
-    const noisy = mde > blockInfo.minDelta;
+    // Use the same resolution rule as individual benchmark classification
+    const runsInconsistent = resolution > runConsistency.minDelta;
     lines.push(
-      noisy
+      runsInconsistent
         ? `${YELLOW}⚠ Inconsistent runs:${RESET} ${DIM}Median timings changed across fresh runs suggesting an unstable machine.${RESET}`
         : `${GREEN}✔ Consistent runs:${RESET} ${DIM}Median timings remained stable across fresh runs.${RESET}`
     );
-    lines.push(`  ${DIM}Median spread: ${spreadStr} across ${blockInfo.blocks} fresh runs.${RESET}`);
-    lines.push(`  ${DIM}Comparison resolution: ~±${(mde * 100).toFixed(1)}%.${RESET}`);
-    if (blockInfo.clockExplained && blockInfo.clockExplained.length > 0) {
-      const explained = median(blockInfo.clockExplained);
+    lines.push(
+      `  ${DIM}Median spread: ${spreadStr} across ${runConsistency.freshRuns} fresh runs.${RESET}`
+    );
+    lines.push(`  ${DIM}Comparison resolution: ~±${(resolution * 100).toFixed(1)}%.${RESET}`);
+    if (
+      runConsistency.calibrationExplainedFractions &&
+      runConsistency.calibrationExplainedFractions.length > 0
+    ) {
+      const explained = median(runConsistency.calibrationExplainedFractions);
       lines.push(
         `  ${DIM}Clock estimate explains ~${(explained * 100).toFixed(0)}% of run-to-run spread.${RESET}`
       );
     }
   }
 
-  if (noisyBenches.length > 0) {
-    if (!hasBlockSummary) {
+  if (affectedBenchmarks.length > 0) {
+    if (!hasRunConsistencySummary) {
       lines.push(
         `${YELLOW}⚠ Unstable samples:${RESET} ${DIM}Timings did not settle suggesting non-deterministic work or runtime interference.${RESET}`
       );
       lines.push(`  ${DIM}Time limit: ${maxCpuTime}s.${RESET}`);
     }
-    lines.push(`  ${DIM}Affected benchmarks (${noisyBenches.length}):${RESET}`);
-    for (const bench of noisyBenches) {
+    lines.push(`  ${DIM}Affected benchmarks (${affectedBenchmarks.length}):${RESET}`);
+    for (const benchmark of affectedBenchmarks) {
       const spread =
-        bench.spread !== undefined ? `  ${YELLOW}±${(bench.spread * 100).toFixed(1)}%${RESET}` : '';
-      lines.push(`    ${YELLOW}⚠${RESET} ${DIM}${bench.name}${RESET}${spread}`);
+        benchmark.runMedianSpread !== undefined
+          ? `  ${YELLOW}±${(benchmark.runMedianSpread * 100).toFixed(1)}%${RESET}`
+          : '';
+      lines.push(`    ${YELLOW}⚠${RESET} ${DIM}${benchmark.name}${RESET}${spread}`);
     }
-  } else if (!hasBlockSummary) {
+  } else if (!hasRunConsistencySummary) {
     lines.push(
       `${GREEN}✔ Stable samples:${RESET} ${DIM}Timings settled within the ${maxCpuTime}s time limit.${RESET}`
     );
@@ -149,40 +156,50 @@ export function replayReport(result: SavedResult, config: LabsConfig): void {
     );
   }
 
-  const noisyBenches: NoisyBench[] = [];
-  const spreads: number[] = [];
-  const clockExplained: number[] = [];
+  const affectedBenchmarks: StabilityAffectedBenchmark[] = [];
+  const runMedianSpreads: number[] = [];
+  const calibrationExplainedFractions: number[] = [];
   for (const f of result.files) {
     for (const b of f.benchmarks) {
       for (const run of b.runs) {
-        // Blocked stats derive noisiness from spread against the current
-        // config; single-block stats carry the engine's convergence flag.
-        const noisy = run.stats?.blocks
-          ? benchResolution(run.stats.blocks.medians) > config.minDelta
-          : !!run.stats?.noisy;
-        if (noisy) {
-          noisyBenches.push({
+        // Fresh runs use comparison resolution; single runs use adaptive
+        // sample stability. These are separate signals with separate causes.
+        const runsInconsistent = run.stats?.blocks
+          ? comparisonResolution(run.stats.blocks.medians) > config.minDelta
+          : false;
+        const samplesUnstable = !run.stats?.blocks && hasUnstableSamples(run.stats);
+        if (runsInconsistent || samplesUnstable) {
+          affectedBenchmarks.push({
             name: run.name || b.alias,
-            ...(run.stats?.blocks ? { spread: blockSpread(run.stats.blocks.medians) } : {}),
+            ...(run.stats?.blocks
+              ? { runMedianSpread: runMedianSpread(run.stats.blocks.medians) }
+              : {}),
           });
         }
         if (run.stats?.blocks) {
-          spreads.push(blockSpread(run.stats.blocks.medians));
-          clockExplained.push(
-            clockExplainedFraction(run.stats.blocks.medians, run.stats.blocks.freqs)
+          runMedianSpreads.push(runMedianSpread(run.stats.blocks.medians));
+          calibrationExplainedFractions.push(
+            calibrationExplainedFraction(run.stats.blocks.medians, run.stats.blocks.freqs)
           );
         }
       }
     }
   }
-  const blocks = result.blocks ?? 1;
+  const freshRuns = result.blocks ?? 1;
   printReportBox(
     result.environment?.freqs ?? [],
-    noisyBenches,
+    affectedBenchmarks,
     config.maxCpuTime!,
     undefined,
     result.hardware.cpu,
-    blocks > 1 ? { blocks, spreads, minDelta: config.minDelta, clockExplained } : undefined
+    freshRuns > 1
+      ? {
+          freshRuns,
+          medianSpreads: runMedianSpreads,
+          minDelta: config.minDelta,
+          calibrationExplainedFractions,
+        }
+      : undefined
   );
 }
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -10,6 +10,8 @@ export interface BlockInfo {
   blocks: number;
   /** Per-bench relative spread of block medians. */
   spreads: number[];
+  /** Configured verdict threshold, so the warning agrees with the noisy flag. */
+  minDelta: number;
 }
 
 export function printReportBox(
@@ -56,12 +58,13 @@ export function printReportBox(
     const spread = median(blockInfo.spreads);
     const mde = minDetectableEffect(spread, blockInfo.blocks);
     const spreadStr = `±${(spread * 100).toFixed(1)}%`;
-    const noisy = spread > 0.03;
+    // Same rule the worker uses to mark benches noisy, so the two agree
+    const noisy = mde > blockInfo.minDelta;
     lines.push(
       `${noisy ? YELLOW + '⚠' : GREEN + '✔'} between-block spread ${spreadStr}${RESET}  ${DIM}(${blockInfo.blocks} blocks/bench)${RESET}`
     );
     lines.push(
-      `  ${DIM}machine floor: comparisons resolve deltas ≥ ±${(mde * 100).toFixed(1)}%${RESET}`
+      `  ${DIM}est. between-run resolution ~±${(mde * 100).toFixed(1)}% (rough guide)${RESET}`
     );
     lines.push('');
   }
@@ -134,7 +137,7 @@ export function replayReport(result: SavedResult, config: LabsConfig): void {
     config.maxCpuTime!,
     undefined,
     result.hardware.cpu,
-    blocks > 1 ? { blocks, spreads } : undefined
+    blocks > 1 ? { blocks, spreads, minDelta: config.minDelta } : undefined
   );
 }
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,7 +1,13 @@
 import type { LabsConfig } from './config.ts';
 import { renderMitata, type RenderedCollection } from './bench/render.ts';
 import type { Context, Stats, Trial } from './bench/types.ts';
-import { blockSpread, clockExplainedFraction, median, minDetectableEffect } from './stats.ts';
+import {
+  benchResolution,
+  blockSpread,
+  clockExplainedFraction,
+  median,
+  minDetectableEffect,
+} from './stats.ts';
 import type { SavedBenchmarkTrial, SavedFile, SavedResult, FreqSample } from './store.ts';
 import { BLUE, BOLD, DIM, GREEN, RESET, YELLOW } from './utils/ansi.ts';
 import { visibleLength } from './utils/format.ts';
@@ -37,7 +43,7 @@ export function printReportBox(
     lines.push('');
   }
   if (envData.length > 0) {
-    const allFreqs = envData.flatMap((e) => [e.runFreq, e.postFreq, ...(e.blockFreqs ?? [])]);
+    const allFreqs = envData.flatMap((e) => [e.runFreq, e.postFreq]);
     const min = Math.min(...allFreqs);
     const max = Math.max(...allFreqs);
     const drift = (max - min) / ((max + min) / 2);
@@ -66,7 +72,7 @@ export function printReportBox(
     const spread = median(blockInfo.spreads);
     const mde = minDetectableEffect(spread, blockInfo.blocks);
     const spreadStr = `±${(spread * 100).toFixed(1)}%`;
-    // Same rule the worker uses to mark benches noisy, so the two agree
+    // Same rule the readers use to derive per-bench noisiness, so the two agree
     const noisy = mde > blockInfo.minDelta;
     lines.push(
       `${noisy ? YELLOW + '⚠' : GREEN + '✔'} between-block spread ${spreadStr}${RESET}  ${DIM}(${blockInfo.blocks} blocks/bench)${RESET}`
@@ -140,10 +146,15 @@ export function replayReport(result: SavedResult, config: LabsConfig): void {
   for (const f of result.files) {
     for (const b of f.benchmarks) {
       for (const run of b.runs) {
-        if (run.stats?.noisy) {
+        // Blocked stats derive noisiness from spread against the current
+        // config; single-block stats carry the engine's convergence flag.
+        const noisy = run.stats?.blocks
+          ? benchResolution(run.stats.blocks.medians) > config.minDelta
+          : !!run.stats?.noisy;
+        if (noisy) {
           noisyBenches.push({
             name: run.name || b.alias,
-            ...(run.stats.blocks ? { spread: blockSpread(run.stats.blocks.medians) } : {}),
+            ...(run.stats?.blocks ? { spread: blockSpread(run.stats.blocks.medians) } : {}),
           });
         }
         if (run.stats?.blocks) {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -272,6 +272,16 @@ export function minDetectableEffect(spread: number, blocks: number): number {
   return 2.8 * spread * Math.sqrt(2 / blocks);
 }
 
+/**
+ * A bench's between-run resolution: the smallest relative delta its
+ * between-block spread could plausibly detect. Derived from saved block
+ * medians on demand — never persisted — so it always reflects the data and
+ * whatever threshold the current config compares it against.
+ */
+export function benchResolution(medians: number[]): number {
+  return minDetectableEffect(blockSpread(medians), medians.length);
+}
+
 /** Smallest attainable two-sided exact Mann-Whitney p-value for two sample sizes. */
 export function minMannWhitneyP(n1: number, n2: number): number {
   if (n1 < 1 || n2 < 1) return 1;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -120,6 +120,28 @@ export function minMeaningfulDelta(a: number[], b: number[], floor: number): num
   return Math.max(floor, NOISE_SCALE * Math.max(relA, relB));
 }
 
+/**
+ * Relative spread of per-block medians: MAD scaled to sigma equivalent, over
+ * the median. Captures how much fresh-process runs of the same bench differ,
+ * which is the variance a single process cannot observe.
+ */
+export function blockSpread(medians: number[]): number {
+  if (medians.length < 2) return 0;
+  const m = median(medians);
+  if (m <= 0) return 0;
+  return (1.4826 * mad(medians)) / m;
+}
+
+/**
+ * Smallest relative delta a comparison of two runs with this between-block
+ * spread can reliably detect (roughly alpha 0.05 at 0.8 power, comparing
+ * means of `blocks` block medians per side).
+ */
+export function minDetectableEffect(spread: number, blocks: number): number {
+  if (blocks < 2 || spread <= 0) return 0;
+  return 2.8 * spread * Math.sqrt(2 / blocks);
+}
+
 export type Verdict = 'faster' | 'slower' | 'neutral';
 
 export interface ClassifyOptions {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -234,26 +234,25 @@ export function hodgesLehmannDelta(
 }
 
 /**
- * Fraction of between-block spread explained by clock differences: compares
- * the spread of raw block medians against the spread of clock-normalized
- * medians (median × block frequency). 1 means the clock explains everything,
- * 0 means normalizing does not help (or hurts).
+ * Fraction of fresh-run median spread explained by calibration-rate
+ * differences. Compares raw run medians with calibration-normalized medians.
+ * A value of 1 means normalization removes all spread; 0 means it does not
+ * help or makes the spread worse.
  */
-export function clockExplainedFraction(medians: number[], freqs: number[]): number {
-  if (medians.length < 2 || medians.length !== freqs.length) return 0;
-  if (freqs.some((f) => !(f > 0))) return 0;
-  const time = blockSpread(medians);
+export function calibrationExplainedFraction(medians: number[], calibrationRates: number[]): number {
+  if (medians.length < 2 || medians.length !== calibrationRates.length) return 0;
+  if (calibrationRates.some((rate) => !(rate > 0))) return 0;
+  const time = runMedianSpread(medians);
   if (time <= 0) return 0;
-  const cycles = blockSpread(medians.map((m, i) => m * freqs[i]));
-  return Math.max(0, Math.min(1, 1 - (cycles / time) ** 2));
+  const normalized = runMedianSpread(medians.map((median, i) => median * calibrationRates[i]));
+  return Math.max(0, Math.min(1, 1 - (normalized / time) ** 2));
 }
 
 /**
- * Relative spread of per-block medians: MAD scaled to sigma equivalent, over
- * the median. Captures how much fresh-process runs of the same bench differ,
- * which is the variance a single process cannot observe.
+ * Relative spread of fresh-run medians: MAD scaled to sigma equivalent, over
+ * the median. Captures process-to-process variation that one run cannot see.
  */
-export function blockSpread(medians: number[]): number {
+export function runMedianSpread(medians: number[]): number {
   if (medians.length < 2) return 0;
   const m = median(medians);
   if (m <= 0) return 0;
@@ -262,24 +261,24 @@ export function blockSpread(medians: number[]): number {
 
 /**
  * Rough planning estimate of the smallest relative delta a comparison of two
- * runs with this between-block spread could detect. The 2.8 constant is the
+ * runs with this fresh-run median spread could detect. The 2.8 constant is the
  * normal-theory factor for alpha 0.05 at 0.8 power comparing equal-size
- * means, while actual verdicts use a rank test on block medians, so treat
+ * means, while actual verdicts use a rank test on run medians, so treat
  * this as an order-of-magnitude guide, not a guarantee.
  */
-export function minDetectableEffect(spread: number, blocks: number): number {
-  if (blocks < 2 || spread <= 0) return 0;
-  return 2.8 * spread * Math.sqrt(2 / blocks);
+export function minDetectableEffect(spread: number, freshRuns: number): number {
+  if (freshRuns < 2 || spread <= 0) return 0;
+  return 2.8 * spread * Math.sqrt(2 / freshRuns);
 }
 
 /**
- * A bench's between-run resolution: the smallest relative delta its
- * between-block spread could plausibly detect. Derived from saved block
- * medians on demand — never persisted — so it always reflects the data and
+ * A benchmark's comparison resolution: the smallest relative delta its
+ * fresh-run median spread could plausibly detect. Derived from saved medians
+ * on demand, so it always reflects the data and
  * whatever threshold the current config compares it against.
  */
-export function benchResolution(medians: number[]): number {
-  return minDetectableEffect(blockSpread(medians), medians.length);
+export function comparisonResolution(medians: number[]): number {
+  return minDetectableEffect(runMedianSpread(medians), medians.length);
 }
 
 /** Smallest attainable two-sided exact Mann-Whitney p-value for two sample sizes. */

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -18,10 +18,57 @@ export function mad(a: number[]): number {
   return median(a.map((v) => Math.abs(v - m)));
 }
 
+/** Largest per-side size where the exact Mann-Whitney null distribution is used. */
+const MW_U_EXACT_MAX = 25;
+
+/**
+ * Exact two-sided Mann-Whitney p-value from the rank-sum null distribution,
+ * built with the standard recurrence in probability form so counts never
+ * overflow. Valid only without ties.
+ */
+function exactMannWhitneyP(n1: number, n2: number, u: number): number {
+  const width = n1 * n2 + 1;
+  // table[m][k] = P(U = k) for m group-one values among m + n combined, n = 0 so far
+  let table: Float64Array[] = Array.from({ length: n1 + 1 }, () => {
+    const row = new Float64Array(width);
+    row[0] = 1;
+    return row;
+  });
+
+  for (let n = 1; n <= n2; n++) {
+    const next: Float64Array[] = [];
+    for (let m = 0; m <= n1; m++) {
+      const row = new Float64Array(width);
+      if (m === 0) {
+        row[0] = 1;
+      } else {
+        // Largest remaining value is from group one with probability m/(m+n),
+        // contributing n to U, otherwise from group two contributing nothing
+        const pm = m / (m + n);
+        const fromOne = next[m - 1];
+        const fromTwo = table[m];
+        for (let k = 0; k < width; k++) {
+          row[k] = pm * (k >= n ? fromOne[k - n] : 0) + (1 - pm) * fromTwo[k];
+        }
+      }
+      next.push(row);
+    }
+    table = next;
+  }
+
+  let cdf = 0;
+  const target = Math.min(u, n1 * n2 - u);
+  for (let k = 0; k <= target; k++) cdf += table[n1][k];
+  // The null distribution is symmetric, so doubling the smaller tail is exact
+  return Math.min(1, 2 * cdf);
+}
+
 /**
  * Mann-Whitney U test (two-tailed).
- * Ranks all combined samples, sums ranks for group A, derives U and p-value
- * via normal approximation. Accurate for n > ~20 (the engine yields 50+ samples).
+ * Ranks all combined samples and sums ranks for group A. Small tie-free
+ * samples (each side ≤ 25, e.g. block medians) get the exact null
+ * distribution. Larger or tied samples use the normal approximation,
+ * accurate for n > ~20.
  *
  * Returns { U, z, p } where p is the two-tailed p-value.
  */
@@ -35,11 +82,13 @@ export function mannWhitneyU(a: number[], b: number[]): { U: number; z: number; 
     (x, y) => x.v - y.v
   );
 
+  let ties = false;
   const ranks = new Float64Array(combined.length);
   let i = 0;
   while (i < combined.length) {
     let j = i;
     while (j < combined.length - 1 && combined[j + 1].v === combined[i].v) j++;
+    if (j > i) ties = true;
     const avgRank = (i + j) / 2 + 1; // 1-indexed
     for (let k = i; k <= j; k++) ranks[k] = avgRank;
     i = j + 1;
@@ -56,6 +105,10 @@ export function mannWhitneyU(a: number[], b: number[]): { U: number; z: number; 
   const mean = (n1 * n2) / 2;
   const sd = Math.sqrt((n1 * n2 * (n1 + n2 + 1)) / 12);
   const z = sd === 0 ? 0 : (U - mean) / sd;
+
+  if (!ties && n1 <= MW_U_EXACT_MAX && n2 <= MW_U_EXACT_MAX) {
+    return { U: U1, z, p: exactMannWhitneyP(n1, n2, Math.round(U)) };
+  }
 
   // Two-tailed p-value via erfc: p = erfc(|z| / sqrt(2))
   const p = erfc(Math.abs(z) / Math.SQRT2);
@@ -133,9 +186,11 @@ export function blockSpread(medians: number[]): number {
 }
 
 /**
- * Smallest relative delta a comparison of two runs with this between-block
- * spread can reliably detect (roughly alpha 0.05 at 0.8 power, comparing
- * means of `blocks` block medians per side).
+ * Rough planning estimate of the smallest relative delta a comparison of two
+ * runs with this between-block spread could detect. The 2.8 constant is the
+ * normal-theory factor for alpha 0.05 at 0.8 power comparing equal-size
+ * means, while actual verdicts use a rank test on block medians, so treat
+ * this as an order-of-magnitude guide, not a guarantee.
  */
 export function minDetectableEffect(spread: number, blocks: number): number {
   if (blocks < 2 || spread <= 0) return 0;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -153,26 +153,99 @@ export function cliffsD(a: number[], b: number[]): number {
   return (more - less) / (n1 * n2);
 }
 
-/**
- * Smallest relative Δp50 worth believing, given how noisy the samples are.
- *
- * Guards against between-run environmental drift (clock speed, thermal state,
- * background load): offsets that shift every sample equally, so they don't
- * shrink with sample count and the MW-U test can't detect them. Per-sample
- * jitter (MAD/median of the noisier run) is used as a proxy for that drift,
- * scaled by a heuristic 3×. Never returns less than `floor`.
- *
- * Stable system (pinned freq): MAD/median ≈ 0.5% → max(floor, 1.5%)
- * Noisy system (Apple Silicon): MAD/median ≈ 2%   → 6%
- */
-const NOISE_SCALE = 3;
+/** Exact tie-free null distribution of the Mann-Whitney U statistic, P(U = u). */
+function mannWhitneyNullDistribution(n1: number, n2: number): Float64Array {
+  const width = n1 * n2 + 1;
+  // table[m][u] = P(U = u) for m group-one values among m + n combined
+  let table: Float64Array[] = Array.from({ length: n1 + 1 }, () => {
+    const row = new Float64Array(width);
+    row[0] = 1;
+    return row;
+  });
 
-export function minMeaningfulDelta(a: number[], b: number[], floor: number): number {
-  const medA = median(a);
-  const medB = median(b);
-  const relA = medA > 0 ? mad(a) / medA : 0;
-  const relB = medB > 0 ? mad(b) / medB : 0;
-  return Math.max(floor, NOISE_SCALE * Math.max(relA, relB));
+  for (let n = 1; n <= n2; n++) {
+    const next: Float64Array[] = [];
+    for (let m = 0; m <= n1; m++) {
+      const row = new Float64Array(width);
+      if (m === 0) {
+        row[0] = 1;
+      } else {
+        // Largest remaining value is from group one with probability m/(m+n),
+        // contributing n to U, otherwise from group two contributing nothing
+        const pm = m / (m + n);
+        const fromOne = next[m - 1];
+        const fromTwo = table[m];
+        for (let u = 0; u < width; u++) {
+          row[u] = pm * (u >= n ? fromOne[u - n] : 0) + (1 - pm) * fromTwo[u];
+        }
+      }
+      next.push(row);
+    }
+    table = next;
+  }
+
+  return table[n1];
+}
+
+/** Largest u with P(U ≤ u) ≤ alpha/2 under the exact null, or -1 if none. */
+function mannWhitneyCriticalU(n1: number, n2: number, alpha: number): number {
+  const dist = mannWhitneyNullDistribution(n1, n2);
+  let cumulative = 0;
+  let critical = -1;
+  for (let u = 0; u < dist.length; u++) {
+    cumulative += dist[u];
+    if (cumulative <= alpha / 2 + 1e-12) critical = u;
+    else break;
+  }
+  return critical;
+}
+
+/**
+ * Hodges-Lehmann relative shift between two positive samples, with a
+ * confidence interval from inverting the exact Mann-Whitney test: the
+ * estimate is the median of all pairwise candidate/baseline ratios and the
+ * interval endpoints are the ratios at the exact critical ranks. Critical
+ * values assume no ties, so ties make the interval slightly conservative.
+ *
+ * Returns relative deltas (ratio − 1); positive means candidate is larger.
+ */
+export function hodgesLehmannDelta(
+  baseline: number[],
+  candidate: number[],
+  alpha = 0.05
+): { delta: number; low: number; high: number } {
+  const ratios: number[] = [];
+  for (const c of candidate) {
+    for (const b of baseline) {
+      if (b > 0) ratios.push(c / b);
+    }
+  }
+  if (ratios.length === 0) return { delta: 0, low: 0, high: 0 };
+  ratios.sort((a, b) => a - b);
+
+  const critical = mannWhitneyCriticalU(baseline.length, candidate.length, alpha);
+  const lowIndex = Math.max(0, critical);
+  const highIndex = Math.min(ratios.length - 1, ratios.length - 1 - Math.max(0, critical));
+  return {
+    delta: median(ratios) - 1,
+    low: ratios[Math.min(lowIndex, highIndex)] - 1,
+    high: ratios[Math.max(lowIndex, highIndex)] - 1,
+  };
+}
+
+/**
+ * Fraction of between-block spread explained by clock differences: compares
+ * the spread of raw block medians against the spread of clock-normalized
+ * medians (median × block frequency). 1 means the clock explains everything,
+ * 0 means normalizing does not help (or hurts).
+ */
+export function clockExplainedFraction(medians: number[], freqs: number[]): number {
+  if (medians.length < 2 || medians.length !== freqs.length) return 0;
+  if (freqs.some((f) => !(f > 0))) return 0;
+  const time = blockSpread(medians);
+  if (time <= 0) return 0;
+  const cycles = blockSpread(medians.map((m, i) => m * freqs[i]));
+  return Math.max(0, Math.min(1, 1 - (cycles / time) ** 2));
 }
 
 /**
@@ -216,18 +289,18 @@ export type Verdict = 'faster' | 'slower' | 'neutral';
 export interface ClassifyOptions {
   /** Mann-Whitney U two-tailed significance level. @default 0.05 */
   alpha?: number;
-  /** Minimum absolute Δp50 ratio to flag a verdict (floor for noise-adjusted threshold). @default 0.05 */
+  /** Minimum |Hodges-Lehmann delta| to flag a verdict (practical significance). @default 0.05 */
   minDelta?: number;
-  /** Minimum |Cliff's d| to flag a verdict. Filters noise on high-variance benches. @default 0.474 */
-  minEffect?: number;
 }
 
 /**
- * Three-gate classification:
- *   1. p ≤ alpha: statistical significance (Mann-Whitney U)
- *   2. |Δp50| ≥ effectiveMinDelta: practical magnitude, noise-adjusted
- *   3. |cliff's d| ≥ minEffect: effect size ("are the distributions actually separated?")
- * All three must hold to declare faster or slower.
+ * Two-gate classification on independent units (block medians):
+ *   1. p ≤ alpha: statistical significance (exact Mann-Whitney U)
+ *   2. |Hodges-Lehmann delta| ≥ minDelta: practical magnitude
+ * Both must hold to declare faster or slower. Cliff's d is reported for
+ * context but not gated: on the same units it is a linear transform of the
+ * U statistic already behind the p-value. The confidence interval comes from
+ * inverting the exact test.
  */
 export function classify(
   baselineSamples: number[],
@@ -237,24 +310,26 @@ export function classify(
   verdict: Verdict;
   p: number;
   d: number;
-  effectiveMinDelta: number;
+  /** Hodges-Lehmann relative delta; positive means candidate is slower. */
+  hl: number;
+  ciLow: number;
+  ciHigh: number;
+  minDelta: number;
 } {
   const alpha = opts?.alpha ?? 0.05;
   const minDelta = opts?.minDelta ?? 0.05;
-  const minEffect = opts?.minEffect ?? 0.474;
-  const effectiveMinDelta = minMeaningfulDelta(baselineSamples, candidateSamples, minDelta);
   const { p } = mannWhitneyU(baselineSamples, candidateSamples);
   const d = cliffsD(baselineSamples, candidateSamples);
+  const {
+    delta: hl,
+    low: ciLow,
+    high: ciHigh,
+  } = hodgesLehmannDelta(baselineSamples, candidateSamples, alpha);
 
   let verdict: Verdict = 'neutral';
-  if (p <= alpha && Math.abs(d) >= minEffect) {
-    const bMed = median(baselineSamples);
-    const cMed = median(candidateSamples);
-    const ratio = bMed > 0 ? Math.abs(cMed - bMed) / bMed : 0;
-    if (ratio >= effectiveMinDelta) {
-      verdict = cMed > bMed ? 'slower' : 'faster';
-    }
+  if (p <= alpha && Math.abs(hl) >= minDelta) {
+    verdict = hl > 0 ? 'slower' : 'faster';
   }
 
-  return { verdict, p, d, effectiveMinDelta };
+  return { verdict, p, d, hl, ciLow, ciHigh, minDelta };
 }

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -18,57 +18,56 @@ export function mad(a: number[]): number {
   return median(a.map((v) => Math.abs(v - m)));
 }
 
-/** Largest per-side size where the exact Mann-Whitney null distribution is used. */
-const MW_U_EXACT_MAX = 25;
+/** Largest combined sample size where the exact Mann-Whitney distribution is used. */
+const MW_U_EXACT_MAX_TOTAL = 50;
 
 /**
- * Exact two-sided Mann-Whitney p-value from the rank-sum null distribution,
- * built with the standard recurrence in probability form so counts never
- * overflow. Valid only without ties.
+ * Exact two-sided Mann-Whitney p-value from the conditional permutation
+ * distribution of the observed ranks. Doubled integer ranks keep tied
+ * midranks exact, while treating equal-valued observations as distinct
+ * assignments gives every allocation of group labels its proper weight.
  */
-function exactMannWhitneyP(n1: number, n2: number, u: number): number {
-  const width = n1 * n2 + 1;
-  // table[m][k] = P(U = k) for m group-one values among m + n combined, n = 0 so far
-  let table: Float64Array[] = Array.from({ length: n1 + 1 }, () => {
-    const row = new Float64Array(width);
-    row[0] = 1;
-    return row;
-  });
+function exactMannWhitneyP(ranks: Float64Array, n1: number, observedRankSum: number): number {
+  const doubledRanks = Array.from(ranks, (rank) => Math.round(rank * 2));
+  const maxRankSum = doubledRanks
+    .slice()
+    .sort((a, b) => b - a)
+    .slice(0, n1)
+    .reduce((sum, rank) => sum + rank, 0);
+  const counts = Array.from({ length: n1 + 1 }, () => new Float64Array(maxRankSum + 1));
+  counts[0][0] = 1;
 
-  for (let n = 1; n <= n2; n++) {
-    const next: Float64Array[] = [];
-    for (let m = 0; m <= n1; m++) {
-      const row = new Float64Array(width);
-      if (m === 0) {
-        row[0] = 1;
-      } else {
-        // Largest remaining value is from group one with probability m/(m+n),
-        // contributing n to U, otherwise from group two contributing nothing
-        const pm = m / (m + n);
-        const fromOne = next[m - 1];
-        const fromTwo = table[m];
-        for (let k = 0; k < width; k++) {
-          row[k] = pm * (k >= n ? fromOne[k - n] : 0) + (1 - pm) * fromTwo[k];
-        }
+  let seen = 0;
+  for (const rank of doubledRanks) {
+    seen++;
+    for (let selected = Math.min(n1, seen); selected >= 1; selected--) {
+      const row = counts[selected];
+      const previous = counts[selected - 1];
+      for (let sum = maxRankSum; sum >= rank; sum--) {
+        row[sum] += previous[sum - rank];
       }
-      next.push(row);
     }
-    table = next;
   }
 
-  let cdf = 0;
-  const target = Math.min(u, n1 * n2 - u);
-  for (let k = 0; k <= target; k++) cdf += table[n1][k];
-  // The null distribution is symmetric, so doubling the smaller tail is exact
-  return Math.min(1, 2 * cdf);
+  const observed = Math.round(observedRankSum * 2);
+  let lower = 0;
+  let upper = 0;
+  let total = 0;
+  for (let sum = 0; sum <= maxRankSum; sum++) {
+    const count = counts[n1][sum];
+    total += count;
+    if (sum <= observed) lower += count;
+    if (sum >= observed) upper += count;
+  }
+
+  return total === 0 ? 1 : Math.min(1, (2 * Math.min(lower, upper)) / total);
 }
 
 /**
  * Mann-Whitney U test (two-tailed).
- * Ranks all combined samples and sums ranks for group A. Small tie-free
- * samples (each side ≤ 25, e.g. block medians) get the exact null
- * distribution. Larger or tied samples use the normal approximation,
- * accurate for n > ~20.
+ * Ranks all combined samples and sums ranks for group A. Samples with at most
+ * 50 values combined get the exact conditional permutation distribution,
+ * including ties. Larger samples use the tie-corrected normal approximation.
  *
  * Returns { U, z, p } where p is the two-tailed p-value.
  */
@@ -82,13 +81,14 @@ export function mannWhitneyU(a: number[], b: number[]): { U: number; z: number; 
     (x, y) => x.v - y.v
   );
 
-  let ties = false;
+  let tieTerm = 0;
   const ranks = new Float64Array(combined.length);
   let i = 0;
   while (i < combined.length) {
     let j = i;
     while (j < combined.length - 1 && combined[j + 1].v === combined[i].v) j++;
-    if (j > i) ties = true;
+    const tieSize = j - i + 1;
+    tieTerm += tieSize ** 3 - tieSize;
     const avgRank = (i + j) / 2 + 1; // 1-indexed
     for (let k = i; k <= j; k++) ranks[k] = avgRank;
     i = j + 1;
@@ -100,14 +100,16 @@ export function mannWhitneyU(a: number[], b: number[]): { U: number; z: number; 
   }
 
   const U1 = R1 - (n1 * (n1 + 1)) / 2;
-  const U = Math.min(U1, n1 * n2 - U1); // use smaller U for the approximation
-
   const mean = (n1 * n2) / 2;
-  const sd = Math.sqrt((n1 * n2 * (n1 + n2 + 1)) / 12);
-  const z = sd === 0 ? 0 : (U - mean) / sd;
+  const total = n1 + n2;
+  const variance = (n1 * n2 * (total + 1 - (total > 1 ? tieTerm / (total * (total - 1)) : 0))) / 12;
+  const sd = Math.sqrt(Math.max(0, variance));
+  const centered = U1 - mean;
+  const continuityCorrected = Math.sign(centered) * Math.max(0, Math.abs(centered) - 0.5);
+  const z = sd === 0 ? 0 : continuityCorrected / sd;
 
-  if (!ties && n1 <= MW_U_EXACT_MAX && n2 <= MW_U_EXACT_MAX) {
-    return { U: U1, z, p: exactMannWhitneyP(n1, n2, Math.round(U)) };
+  if (total <= MW_U_EXACT_MAX_TOTAL) {
+    return { U: U1, z, p: exactMannWhitneyP(ranks, n1, R1) };
   }
 
   // Two-tailed p-value via erfc: p = erfc(|z| / sqrt(2))
@@ -195,6 +197,18 @@ export function blockSpread(medians: number[]): number {
 export function minDetectableEffect(spread: number, blocks: number): number {
   if (blocks < 2 || spread <= 0) return 0;
   return 2.8 * spread * Math.sqrt(2 / blocks);
+}
+
+/** Smallest attainable two-sided exact Mann-Whitney p-value for two sample sizes. */
+export function minMannWhitneyP(n1: number, n2: number): number {
+  if (n1 < 1 || n2 < 1) return 1;
+  const total = n1 + n2;
+  const selected = Math.min(n1, n2);
+  let logCombinations = 0;
+  for (let i = 1; i <= selected; i++) {
+    logCombinations += Math.log(total - selected + i) - Math.log(i);
+  }
+  return Math.min(1, 2 * Math.exp(-logCombinations));
 }
 
 export type Verdict = 'faster' | 'slower' | 'neutral';

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import type { GcMode, Stats } from './bench/types.ts';
+import type { BlockPlan, GcMode, Stats } from './bench/types.ts';
 
 export interface GitInfo {
   /** Full sha of HEAD when the run was saved. */
@@ -31,6 +31,8 @@ export interface SavedStats {
   noisy?: boolean;
   gc?: { avg: number; min: number; max: number };
   heap?: { avg: number; min: number; max: number };
+  plan?: BlockPlan;
+  blocks?: { medians: number[]; freqs: number[] };
 }
 
 export interface WorkerBenchmarkRun {
@@ -117,6 +119,8 @@ export interface FreqSample {
   preFreq?: number;
   runFreq: number;
   postFreq: number;
+  /** Per-block clock probes when the file ran with blocked sampling. */
+  blockFreqs?: number[];
 }
 
 export interface SavedResult {
@@ -130,6 +134,11 @@ export interface SavedResult {
    * file.
    */
   isolation?: 'bench' | 'file';
+  /**
+   * Fresh-process blocks each bench ran as. An omitted value means one block,
+   * so saved spreads exclude between-process variance.
+   */
+  blocks?: number;
   context?: {
     version?: string | null;
     noop?: {
@@ -148,7 +157,7 @@ export interface LastComparison {
 }
 
 function freqReadings(freqs: FreqSample[]): number[] {
-  return freqs.flatMap((s) => [s.runFreq, s.postFreq]);
+  return freqs.flatMap((s) => [s.runFreq, s.postFreq, ...(s.blockFreqs ?? [])]);
 }
 
 /** Returns true if the CPU clock was stable during the run (drift ≤ threshold). */
@@ -315,6 +324,8 @@ export function trimStats(stats: Stats): SavedStats {
     p75: stats.p75,
     p99: stats.p99,
     ...(stats.noisy !== undefined ? { noisy: stats.noisy } : {}),
+    ...(stats.plan ? { plan: stats.plan } : {}),
+    ...(stats.blocks ? { blocks: stats.blocks } : {}),
     ...(stats.gc
       ? {
           gc: {

--- a/src/store.ts
+++ b/src/store.ts
@@ -119,8 +119,6 @@ export interface FreqSample {
   preFreq?: number;
   runFreq: number;
   postFreq: number;
-  /** Per-block clock probes when the file ran with blocked sampling. */
-  blockFreqs?: number[];
 }
 
 export interface SavedResult {
@@ -157,7 +155,9 @@ export interface LastComparison {
 }
 
 function freqReadings(freqs: FreqSample[]): number[] {
-  return freqs.flatMap((s) => [s.runFreq, s.postFreq, ...(s.blockFreqs ?? [])]);
+  // Only the two long calibrated readings: the cheap per-block probes use a
+  // different warmup/budget and would read their calibration offset as drift.
+  return freqs.flatMap((s) => [s.runFreq, s.postFreq]);
 }
 
 /** Returns true if the CPU clock was stable during the run (drift ≤ threshold). */

--- a/src/store.ts
+++ b/src/store.ts
@@ -28,11 +28,18 @@ export interface SavedStats {
   p25: number;
   p75: number;
   p99: number;
+  /** Adaptive samples did not settle before the measurement time limit. */
+  samplesUnstable?: boolean;
+  /** @deprecated Compatibility field for older saved results. */
   noisy?: boolean;
   gc?: { avg: number; min: number; max: number };
   heap?: { avg: number; min: number; max: number };
   plan?: BlockPlan;
-  blocks?: { medians: number[]; freqs: number[] };
+  blocks?: {
+    medians: number[];
+    /** Software calibration rates. The `freqs` name is retained for schema compatibility. */
+    freqs: number[];
+  };
 }
 
 export interface WorkerBenchmarkRun {
@@ -313,6 +320,7 @@ function normalizeTrial(
 }
 
 export function trimStats(stats: Stats): SavedStats {
+  const samplesUnstable = stats.samplesUnstable ?? stats.noisy;
   return {
     kind: stats.kind,
     samples: stats.samples,
@@ -323,7 +331,13 @@ export function trimStats(stats: Stats): SavedStats {
     p25: stats.p25,
     p75: stats.p75,
     p99: stats.p99,
-    ...(stats.noisy !== undefined ? { noisy: stats.noisy } : {}),
+    ...(samplesUnstable !== undefined
+      ? {
+          samplesUnstable,
+          // Keep older Labs versions able to read the same saved result
+          noisy: samplesUnstable,
+        }
+      : {}),
     ...(stats.plan ? { plan: stats.plan } : {}),
     ...(stats.blocks ? { blocks: stats.blocks } : {}),
     ...(stats.gc

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -4,9 +4,10 @@ import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { stripVTControlCharacters } from 'node:util';
+import { describe, expect, it, vi } from 'vitest';
 import { measure } from '../src/bench/index.ts';
-import { compare } from '../src/compare.ts';
+import { compare, printCompareReport } from '../src/compare.ts';
 import { defineConfig } from '../src/config.ts';
 import { blockSpread, mannWhitneyU, minDetectableEffect } from '../src/stats.ts';
 import type { SavedResult } from '../src/store.ts';
@@ -242,6 +243,32 @@ describe('comparing blocked results', () => {
       expect(bench.verdict).toBe('slower');
       expect(bench.resolution).toBeGreaterThan(CONFIG.minDelta);
     }
+  });
+
+  it('right-aligns noisy resolution beneath the confidence interval', () => {
+    const aMedians = [100, 92, 108, 95, 105, 90, 110, 99];
+    const bMedians = aMedians.map((m) => m * 1.5);
+    const result = compare(syntheticResult('a', aMedians), syntheticResult('b', bMedians), CONFIG);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    let lines: string[] = [];
+
+    try {
+      printCompareReport(result, CONFIG);
+      lines = log.mock.calls.map(([line]) => stripVTControlCharacters(String(line)));
+    } finally {
+      log.mockRestore();
+    }
+
+    const header = lines.find((line) => line.includes('Δ 95% CI'));
+    const warningIndex = lines.findIndex((line) => line.includes('⚠ ~±'));
+    const warning = lines[warningIndex];
+
+    expect(header).toBeDefined();
+    expect(warning).toBeDefined();
+    expect(lines[warningIndex - 1]).toContain('unit');
+    expect(warning).toHaveLength(header!.length);
+    expect(warning).toMatch(/⚠ ~±\d+%$/);
+    expect(lines).toContain('⚠ Neutral means inconclusive at the shown resolution.');
   });
 
   it('points isolation-disabled runs at isolate, not at re-saving', () => {

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { measure } from '../src/bench/index.ts';
 import { compare, printCompareReport } from '../src/compare.ts';
 import { defineConfig } from '../src/config.ts';
-import { blockSpread, mannWhitneyU, minDetectableEffect } from '../src/stats.ts';
+import { mannWhitneyU, minDetectableEffect, runMedianSpread } from '../src/stats.ts';
 import type { SavedResult } from '../src/store.ts';
 
 const fast = { min_cpu_time: 1, min_samples: 12, adaptive: false } as const;
@@ -31,7 +31,7 @@ function syntheticStats(blockMedians: number[], freq = 4, perBlock = 40) {
     p25: q(0.25),
     p75: q(0.75),
     p99: q(0.99),
-    noisy: false,
+    samplesUnstable: false,
     blocks: { medians: blockMedians, freqs: blockMedians.map(() => freq) },
   };
 }
@@ -102,21 +102,21 @@ describe('measurement plans', () => {
   });
 });
 
-describe('between-block statistics', () => {
-  it('reports zero spread for identical or single-block medians', () => {
-    expect(blockSpread([100, 100, 100])).toBe(0);
-    expect(blockSpread([100])).toBe(0);
+describe('fresh-run statistics', () => {
+  it('reports zero spread for identical or single-run medians', () => {
+    expect(runMedianSpread([100, 100, 100])).toBe(0);
+    expect(runMedianSpread([100])).toBe(0);
   });
 
-  it('scales spread with block median dispersion', () => {
-    const tight = blockSpread([99, 100, 101, 100]);
-    const wide = blockSpread([80, 100, 120, 100]);
+  it('scales spread with fresh-run median dispersion', () => {
+    const tight = runMedianSpread([99, 100, 101, 100]);
+    const wide = runMedianSpread([80, 100, 120, 100]);
 
     expect(tight).toBeGreaterThan(0);
     expect(wide).toBeGreaterThan(tight);
   });
 
-  it('derives a detectable-effect floor from spread and block count', () => {
+  it('derives a detectable-effect floor from spread and fresh-run count', () => {
     expect(minDetectableEffect(0.02, 8)).toBeCloseTo(0.028, 5);
     expect(minDetectableEffect(0.02, 16)).toBeLessThan(minDetectableEffect(0.02, 8));
     expect(minDetectableEffect(0.02, 1)).toBe(0);
@@ -184,9 +184,9 @@ describe('comparing blocked results', () => {
     }
   });
 
-  it('skips clock-confounded verdicts where time and cycles disagree', () => {
+  it('skips clock-confounded verdicts when calibration normalization changes the verdict', () => {
     // The candidate is slower in wall time purely because its blocks ran at a
-    // lower clock: in cycles the two sides are identical
+    // lower calibration rate: normalized timings are identical
     const aMedians = [100, 100.4, 99.7, 100.2, 99.9, 100.1, 99.8, 100.3];
     const bMedians = aMedians.map((m) => m * (4.0 / 3.5));
     const a = syntheticResult('a', aMedians);
@@ -221,7 +221,7 @@ describe('comparing blocked results', () => {
 
   it('keeps verdicts when clocks are effectively equal despite probe jitter', () => {
     // A real 6% regression with a candidate clock only ~1% lower: judged in
-    // cycles the shift shrinks below minDelta, but a 1% clock difference is
+    // normalization shrinks the shift below minDelta, but a 1% rate difference is
     // within probe jitter, so the cross-check must stay inert instead of
     // eating the verdict
     const aMedians = [100, 100.4, 99.7, 100.2, 99.9, 100.1, 99.8, 100.3];
@@ -251,10 +251,10 @@ describe('comparing blocked results', () => {
     }
   });
 
-  it('judges large effects on noisy benches and reports their resolution', () => {
-    // ~6% between-block spread cannot resolve minDelta=5%, but a 50% shift
+  it('judges large effects despite limited resolution and reports that resolution', () => {
+    // ~6% fresh-run spread cannot resolve minDelta=5%, but a 50% shift
     // with fully separated blocks is unambiguous: the bench keeps its verdict
-    // and carries its resolution for the report's noisy annotation
+    // and carries its resolution for the report's limited-resolution annotation
     const aMedians = [100, 92, 108, 95, 105, 90, 110, 99];
     const bMedians = aMedians.map((m) => m * 1.5);
 
@@ -263,11 +263,11 @@ describe('comparing blocked results', () => {
     expect(bench.kind).toBe('eligible');
     if (bench.kind === 'eligible') {
       expect(bench.verdict).toBe('slower');
-      expect(bench.resolution).toBeGreaterThan(CONFIG.minDelta);
+      expect(bench.comparisonResolution).toBeGreaterThan(CONFIG.minDelta);
     }
   });
 
-  it('right-aligns noisy resolution beneath the confidence interval', () => {
+  it('right-aligns limited resolution beneath the confidence interval', () => {
     const aMedians = [100, 92, 108, 95, 105, 90, 110, 99];
     const bMedians = aMedians.map((m) => m * 1.5);
     const result = compare(syntheticResult('a', aMedians), syntheticResult('b', bMedians), CONFIG);

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -156,6 +156,50 @@ describe('comparing blocked results', () => {
     if (bench.kind === 'eligible') expect(bench.verdict).toBe('slower');
   });
 
+  it('reports p50 and delta from the block medians used for the verdict', () => {
+    const aMedians = [90, 91, 92, 93, 94, 95, 96, 97];
+    const bMedians = [96.1, 97.1, 98.1, 99.1, 100.1, 101.1, 102.1, 103.1];
+    const a = syntheticResult('a', aMedians);
+    const b = syntheticResult('b', bMedians);
+    const aStats = a.files[0].benchmarks[0].runs[0].stats!;
+    const bStats = b.files[0].benchmarks[0].runs[0].stats!;
+
+    // These skewed inner samples make the pooled p50 move slightly faster,
+    // opposite to the independently replicated block-median effect.
+    aStats.samples = aMedians
+      .flatMap((m) => [...Array(11).fill(m), ...Array(9).fill(1_000)])
+      .sort((x, y) => x - y);
+    bStats.samples = bMedians
+      .flatMap((m) => [...Array(9).fill(50), ...Array(11).fill(m)])
+      .sort((x, y) => x - y);
+
+    const bench = compare(a, b, CONFIG).benches[0];
+    expect(bench.kind).toBe('eligible');
+    if (bench.kind === 'eligible') {
+      expect(bench.verdict).toBe('slower');
+      expect(bench.baselineP50).toBe(93.5);
+      expect(bench.candidateP50).toBeCloseTo(99.6, 10);
+      expect(bench.deltaP50).toBeGreaterThan(0.05);
+    }
+  });
+
+  it('allows four blocks at alpha 0.05 but respects stricter alpha', () => {
+    const aMedians = [99.8, 100, 100.2, 100.4];
+    const bMedians = aMedians.map((m) => m * 1.2);
+    const a = syntheticResult('a', aMedians);
+    const b = syntheticResult('b', bMedians);
+
+    const defaultBench = compare(a, b, CONFIG).benches[0];
+    expect(defaultBench.kind).toBe('eligible');
+    if (defaultBench.kind === 'eligible') expect(defaultBench.verdict).toBe('slower');
+
+    const strictBench = compare(a, b, defineConfig({ benchDir: '.', alpha: 0.01 })).benches[0];
+    expect(strictBench.kind).toBe('skipped');
+    if (strictBench.kind === 'skipped') {
+      expect(strictBench.reason).toContain('cannot reach α=0.01');
+    }
+  });
+
   it('skips benches without block replication instead of judging them', () => {
     const medians = [100, 101, 99, 100, 100, 101, 99, 100];
     const legacy = syntheticResult('old', medians, { legacy: true });

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -38,7 +38,7 @@ function syntheticStats(blockMedians: number[], freq = 4, perBlock = 40) {
 function syntheticResult(
   name: string,
   blockMedians: number[],
-  opts: { legacy?: boolean; freq?: number } = {}
+  opts: { legacy?: boolean; freq?: number; isolation?: 'bench' | 'file' } = {}
 ): SavedResult {
   const stats = syntheticStats(blockMedians, opts.freq ?? 4);
   if (opts.legacy) delete (stats as any).blocks;
@@ -46,7 +46,7 @@ function syntheticResult(
     name,
     timestamp: '2026-01-01T00:00:00.000Z',
     hardware: { cpu: 'test-cpu', arch: 'test', runtime: 'node', freq: 4 },
-    isolation: 'bench',
+    isolation: opts.isolation ?? 'bench',
     ...(opts.legacy ? {} : { blocks: blockMedians.length }),
     files: [
       {
@@ -196,6 +196,21 @@ describe('comparing blocked results', () => {
     if (bench.kind === 'skipped') expect(bench.reason).toContain('clock-confounded');
   });
 
+  it('keeps verdicts when clocks are effectively equal despite probe jitter', () => {
+    // A real 6% regression with a candidate clock only ~1% lower: judged in
+    // cycles the shift shrinks below minDelta, but a 1% clock difference is
+    // within probe jitter, so the cross-check must stay inert instead of
+    // eating the verdict
+    const aMedians = [100, 100.4, 99.7, 100.2, 99.9, 100.1, 99.8, 100.3];
+    const bMedians = aMedians.map((m) => m * 1.06);
+    const a = syntheticResult('a', aMedians);
+    const b = syntheticResult('b', bMedians, { freq: 3.96 });
+
+    const bench = compare(a, b, CONFIG).benches[0];
+    expect(bench.kind).toBe('eligible');
+    if (bench.kind === 'eligible') expect(bench.verdict).toBe('slower');
+  });
+
   it('allows four blocks at alpha 0.05 but respects stricter alpha', () => {
     const aMedians = [99.8, 100, 100.2, 100.4];
     const bMedians = aMedians.map((m) => m * 1.2);
@@ -210,6 +225,35 @@ describe('comparing blocked results', () => {
     expect(strictBench.kind).toBe('skipped');
     if (strictBench.kind === 'skipped') {
       expect(strictBench.reason).toContain('cannot reach α=0.01');
+    }
+  });
+
+  it('judges large effects on noisy benches and reports their resolution', () => {
+    // ~6% between-block spread cannot resolve minDelta=5%, but a 50% shift
+    // with fully separated blocks is unambiguous: the bench keeps its verdict
+    // and carries its resolution for the report's noisy annotation
+    const aMedians = [100, 92, 108, 95, 105, 90, 110, 99];
+    const bMedians = aMedians.map((m) => m * 1.5);
+
+    const bench = compare(syntheticResult('a', aMedians), syntheticResult('b', bMedians), CONFIG)
+      .benches[0];
+    expect(bench.kind).toBe('eligible');
+    if (bench.kind === 'eligible') {
+      expect(bench.verdict).toBe('slower');
+      expect(bench.resolution).toBeGreaterThan(CONFIG.minDelta);
+    }
+  });
+
+  it('points isolation-disabled runs at isolate, not at re-saving', () => {
+    const medians = [100, 101, 99, 100, 100, 101, 99, 100];
+    const shared = syntheticResult('shared', medians, { legacy: true, isolation: 'file' });
+    const fresh = syntheticResult('fresh', medians);
+
+    const bench = compare(shared, fresh, CONFIG).benches[0];
+    expect(bench.kind).toBe('skipped');
+    if (bench.kind === 'skipped') {
+      expect(bench.reason).toContain('requires isolation');
+      expect(bench.reason).not.toContain('re-save with blocked sampling');
     }
   });
 
@@ -292,9 +336,7 @@ describe('worker blocked sampling', () => {
   }
 
   it('judges two blocked runs of the same code as neutral', { timeout: 120_000, retry: 2 }, () => {
-    // A wide noisy threshold keeps the machine-floor flag out of the way so
-    // the A/A assertion exercises the verdict path itself
-    const env = { LABS_BLOCKS: '5', LABS_MIN_DELTA: '0.5' };
+    const env = { LABS_BLOCKS: '5' };
     const a = runWorker(env);
     const b = runWorker(env);
 

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -197,6 +197,28 @@ describe('comparing blocked results', () => {
     if (bench.kind === 'skipped') expect(bench.reason).toContain('clock-confounded');
   });
 
+  it('renders clock-confounded skips as a compact table', () => {
+    const aMedians = [100, 100.4, 99.7, 100.2, 99.9, 100.1, 99.8, 100.3];
+    const bMedians = aMedians.map((m) => m * (4.0 / 3.5));
+    const result = compare(
+      syntheticResult('a', aMedians),
+      syntheticResult('b', bMedians, { freq: 3.5 }),
+      CONFIG
+    );
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    let lines: string[] = [];
+
+    try {
+      printCompareReport(result, CONFIG);
+      lines = log.mock.calls.map(([line]) => stripVTControlCharacters(String(line)));
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(lines).toContain('  clock-confounded');
+    expect(lines).toContain('  · unit              slower→neutral · 4.00→3.50');
+  });
+
   it('keeps verdicts when clocks are effectively equal despite probe jitter', () => {
     // A real 6% regression with a candidate clock only ~1% lower: judged in
     // cycles the shift shrinks below minDelta, but a 1% clock difference is

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -14,7 +14,7 @@ import type { SavedResult } from '../src/store.ts';
 const fast = { min_cpu_time: 1, min_samples: 12, adaptive: false } as const;
 const CONFIG = defineConfig({ benchDir: '.' });
 
-function syntheticStats(blockMedians: number[], perBlock = 40) {
+function syntheticStats(blockMedians: number[], freq = 4, perBlock = 40) {
   const samples: number[] = [];
   for (const m of blockMedians) {
     for (let i = 0; i < perBlock; i++) samples.push(m + ((i % 5) - 2) * 0.01);
@@ -31,16 +31,16 @@ function syntheticStats(blockMedians: number[], perBlock = 40) {
     p75: q(0.75),
     p99: q(0.99),
     noisy: false,
-    blocks: { medians: blockMedians, freqs: blockMedians.map(() => 4) },
+    blocks: { medians: blockMedians, freqs: blockMedians.map(() => freq) },
   };
 }
 
 function syntheticResult(
   name: string,
   blockMedians: number[],
-  opts: { legacy?: boolean } = {}
+  opts: { legacy?: boolean; freq?: number } = {}
 ): SavedResult {
-  const stats = syntheticStats(blockMedians);
+  const stats = syntheticStats(blockMedians, opts.freq ?? 4);
   if (opts.legacy) delete (stats as any).blocks;
   return {
     name,
@@ -181,6 +181,19 @@ describe('comparing blocked results', () => {
       expect(bench.candidateP50).toBeCloseTo(99.6, 10);
       expect(bench.deltaP50).toBeGreaterThan(0.05);
     }
+  });
+
+  it('skips clock-confounded verdicts where time and cycles disagree', () => {
+    // The candidate is slower in wall time purely because its blocks ran at a
+    // lower clock: in cycles the two sides are identical
+    const aMedians = [100, 100.4, 99.7, 100.2, 99.9, 100.1, 99.8, 100.3];
+    const bMedians = aMedians.map((m) => m * (4.0 / 3.5));
+    const a = syntheticResult('a', aMedians);
+    const b = syntheticResult('b', bMedians, { freq: 3.5 });
+
+    const bench = compare(a, b, CONFIG).benches[0];
+    expect(bench.kind).toBe('skipped');
+    if (bench.kind === 'skipped') expect(bench.reason).toContain('clock-confounded');
   });
 
   it('allows four blocks at alpha 0.05 but respects stricter alpha', () => {

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -290,7 +290,9 @@ describe('comparing blocked results', () => {
     expect(lines[warningIndex - 1]).toContain('unit');
     expect(warning).toHaveLength(header!.length);
     expect(warning).toMatch(/⚠ ~±\d+%$/);
-    expect(lines).toContain('⚠ Neutral means inconclusive at the shown resolution.');
+    expect(lines).toContain(
+      '⚠ Limited resolution: Neutral results are inconclusive at the shown resolution.'
+    );
   });
 
   it('points isolation-disabled runs at isolate, not at re-saving', () => {

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -6,9 +6,67 @@ import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { measure } from '../src/bench/index.ts';
-import { blockSpread, classify, minDetectableEffect } from '../src/stats.ts';
+import { compare } from '../src/compare.ts';
+import { defineConfig } from '../src/config.ts';
+import { blockSpread, mannWhitneyU, minDetectableEffect } from '../src/stats.ts';
+import type { SavedResult } from '../src/store.ts';
 
 const fast = { min_cpu_time: 1, min_samples: 12, adaptive: false } as const;
+const CONFIG = defineConfig({ benchDir: '.' });
+
+function syntheticStats(blockMedians: number[], perBlock = 40) {
+  const samples: number[] = [];
+  for (const m of blockMedians) {
+    for (let i = 0; i < perBlock; i++) samples.push(m + ((i % 5) - 2) * 0.01);
+  }
+  samples.sort((a, b) => a - b);
+  const q = (p: number) => samples[(p * (samples.length - 1)) | 0];
+  return {
+    kind: 'fn' as const,
+    samples,
+    min: samples[0],
+    max: samples[samples.length - 1],
+    avg: samples.reduce((a, v) => a + v, 0) / samples.length,
+    p25: q(0.25),
+    p75: q(0.75),
+    p99: q(0.99),
+    noisy: false,
+    blocks: { medians: blockMedians, freqs: blockMedians.map(() => 4) },
+  };
+}
+
+function syntheticResult(
+  name: string,
+  blockMedians: number[],
+  opts: { legacy?: boolean } = {}
+): SavedResult {
+  const stats = syntheticStats(blockMedians);
+  if (opts.legacy) delete (stats as any).blocks;
+  return {
+    name,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    hardware: { cpu: 'test-cpu', arch: 'test', runtime: 'node', freq: 4 },
+    isolation: 'bench',
+    ...(opts.legacy ? {} : { blocks: blockMedians.length }),
+    files: [
+      {
+        file: 'synthetic.bench.ts',
+        benchmarks: [
+          {
+            alias: 'unit',
+            group: 0,
+            baseline: false,
+            gcMode: true,
+            kind: 'static',
+            style: { compact: false, highlight: false },
+            runs: [{ name: 'unit', args: {}, stats }],
+          },
+        ],
+      },
+    ],
+    environment: { freqs: [] },
+  } as SavedResult;
+}
 
 describe('measurement plans', () => {
   it('reports the plan a measurement decided on', async () => {
@@ -65,6 +123,53 @@ describe('between-block statistics', () => {
   });
 });
 
+describe('comparing blocked results', () => {
+  it('tests block medians, not pooled samples', () => {
+    // Overlapping block medians with a 6% shift: no independent replication
+    // supports a verdict, but the pooled inner samples look wildly separated
+    const aMedians = [100, 92, 108, 95, 105, 90, 110, 99];
+    const bMedians = aMedians.map((m) => m * 1.06);
+    const a = syntheticResult('a', aMedians);
+    const b = syntheticResult('b', bMedians);
+
+    const pooledP = mannWhitneyU(
+      a.files[0].benchmarks[0].runs[0].stats!.samples,
+      b.files[0].benchmarks[0].runs[0].stats!.samples
+    ).p;
+    expect(pooledP).toBeLessThan(1e-6);
+
+    const bench = compare(a, b, CONFIG).benches[0];
+    expect(bench.kind).toBe('eligible');
+    if (bench.kind === 'eligible') {
+      expect(bench.p).toBeGreaterThan(0.05);
+      expect(bench.verdict).toBe('neutral');
+    }
+  });
+
+  it('flags real shifts that block replication does support', () => {
+    const aMedians = [100, 100.4, 99.7, 100.2, 99.9, 100.1, 99.8, 100.3];
+    const bMedians = aMedians.map((m) => m * 1.2);
+
+    const bench = compare(syntheticResult('a', aMedians), syntheticResult('b', bMedians), CONFIG)
+      .benches[0];
+    expect(bench.kind).toBe('eligible');
+    if (bench.kind === 'eligible') expect(bench.verdict).toBe('slower');
+  });
+
+  it('skips benches without block replication instead of judging them', () => {
+    const medians = [100, 101, 99, 100, 100, 101, 99, 100];
+    const legacy = syntheticResult('old', medians, { legacy: true });
+    const fresh = syntheticResult('new', medians);
+
+    const result = compare(legacy, fresh, CONFIG);
+    expect(result.benches[0].kind).toBe('skipped');
+    if (result.benches[0].kind === 'skipped') {
+      expect(result.benches[0].reason).toContain('block replication');
+    }
+    expect(result.environmentWarnings.some((w) => w.includes('block counts'))).toBe(true);
+  });
+});
+
 describe('worker blocked sampling', () => {
   const WORKER = fileURLToPath(new URL('../src/worker.ts', import.meta.url));
   const FIXTURE = fileURLToPath(new URL('./fixtures/blocks.bench.ts', import.meta.url));
@@ -117,15 +222,31 @@ describe('worker blocked sampling', () => {
     }
   });
 
+  function toSavedResult(name: string, workerResult: any): SavedResult {
+    return {
+      name,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      hardware: { cpu: 'test-cpu', arch: 'test', runtime: 'node', freq: 4 },
+      isolation: 'bench',
+      blocks: 5,
+      files: [{ file: 'blocks.bench.ts', benchmarks: workerResult.benchmarks }],
+      environment: { freqs: [] },
+    } as SavedResult;
+  }
+
   it('judges two blocked runs of the same code as neutral', { timeout: 120_000, retry: 2 }, () => {
-    const a = runWorker({ LABS_BLOCKS: '3' });
-    const b = runWorker({ LABS_BLOCKS: '3' });
+    // A wide noisy threshold keeps the machine-floor flag out of the way so
+    // the A/A assertion exercises the verdict path itself
+    const env = { LABS_BLOCKS: '5', LABS_MIN_DELTA: '0.5' };
+    const a = runWorker(env);
+    const b = runWorker(env);
 
-    const { verdict } = classify(
-      a.benchmarks[0].runs[0].stats.samples,
-      b.benchmarks[0].runs[0].stats.samples
-    );
+    const result = compare(toSavedResult('a', a), toSavedResult('b', b), CONFIG);
+    const eligible = result.benches.filter((bench) => bench.kind === 'eligible');
 
-    expect(verdict).toBe('neutral');
+    expect(eligible).toHaveLength(2);
+    for (const bench of eligible) {
+      if (bench.kind === 'eligible') expect(bench.verdict).toBe('neutral');
+    }
   });
 });

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -1,0 +1,131 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { measure } from '../src/bench/index.ts';
+import { blockSpread, classify, minDetectableEffect } from '../src/stats.ts';
+
+const fast = { min_cpu_time: 1, min_samples: 12, adaptive: false } as const;
+
+describe('measurement plans', () => {
+  it('reports the plan a measurement decided on', async () => {
+    const stats = await measure(() => 1 + 1, fast);
+
+    expect(stats.plan?.batch).toBe(true);
+    expect(stats.plan?.batch_samples).toBeGreaterThan(0);
+    expect(stats.plan?.samples).toBeGreaterThanOrEqual(12);
+  });
+
+  it('replays a frozen plan exactly', async () => {
+    const stats = await measure(() => 1 + 1, {
+      batch: false,
+      batch_samples: 4096,
+      batch_unroll: 4,
+      min_samples: 20,
+      max_samples: 20,
+      min_cpu_time: 0,
+      adaptive: false,
+    });
+
+    expect(stats.plan).toMatchObject({ batch: false, samples: 20 });
+    // 20 raw samples exceed the trim threshold so 2 are dropped from each tail
+    expect(stats.samples.length).toBe(16);
+  });
+
+  it('forces batching on when the plan says so', async () => {
+    const stats = await measure(() => 1 + 1, { ...fast, batch: true });
+
+    expect(stats.plan?.batch).toBe(true);
+    expect(stats.ticks).toBeGreaterThan(stats.samples.length);
+  });
+});
+
+describe('between-block statistics', () => {
+  it('reports zero spread for identical or single-block medians', () => {
+    expect(blockSpread([100, 100, 100])).toBe(0);
+    expect(blockSpread([100])).toBe(0);
+  });
+
+  it('scales spread with block median dispersion', () => {
+    const tight = blockSpread([99, 100, 101, 100]);
+    const wide = blockSpread([80, 100, 120, 100]);
+
+    expect(tight).toBeGreaterThan(0);
+    expect(wide).toBeGreaterThan(tight);
+  });
+
+  it('derives a detectable-effect floor from spread and block count', () => {
+    expect(minDetectableEffect(0.02, 8)).toBeCloseTo(0.028, 5);
+    expect(minDetectableEffect(0.02, 16)).toBeLessThan(minDetectableEffect(0.02, 8));
+    expect(minDetectableEffect(0.02, 1)).toBe(0);
+    expect(minDetectableEffect(0, 8)).toBe(0);
+  });
+});
+
+describe('worker blocked sampling', () => {
+  const WORKER = fileURLToPath(new URL('../src/worker.ts', import.meta.url));
+  const FIXTURE = fileURLToPath(new URL('./fixtures/blocks.bench.ts', import.meta.url));
+  const TSX = pathToFileURL(createRequire(import.meta.url).resolve('tsx')).href;
+  let spawnCount = 0;
+
+  function runWorker(env: Record<string, string>) {
+    const resultFile = join(tmpdir(), `labs-blocks-test-${process.pid}-${spawnCount++}.json`);
+    try {
+      execFileSync(process.execPath, ['--import', TSX, WORKER], {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        env: {
+          ...process.env,
+          LABS_BENCH_FILE: pathToFileURL(FIXTURE).href,
+          LABS_RESULT_FILE: resultFile,
+          LABS_MIN_CPU_TIME: '1',
+          LABS_MIN_SAMPLES: '12',
+          LABS_ADAPTIVE: 'false',
+          ...env,
+        },
+      });
+      return JSON.parse(readFileSync(resultFile, 'utf-8'));
+    } finally {
+      rmSync(resultFile, { force: true });
+    }
+  }
+
+  it('runs each bench as N fresh blocks and pools the samples', { timeout: 60_000 }, () => {
+    const result = runWorker({ LABS_BLOCKS: '3' });
+
+    expect(result.benchmarks).toHaveLength(2);
+    for (const trial of result.benchmarks) {
+      const stats = trial.runs[0].stats;
+      expect(trial.runs[0].error).toBeUndefined();
+      expect(stats.blocks.medians).toHaveLength(3);
+      expect(stats.blocks.freqs).toHaveLength(3);
+      expect(stats.blocks.freqs.every((f: number) => f > 0)).toBe(true);
+      // The pilot plan fixes 12 samples per block, pooled across 3 blocks
+      expect(stats.plan.samples).toBe(12);
+      expect(stats.samples).toHaveLength(36);
+    }
+  });
+
+  it('keeps single-block runs identical to unblocked sampling', { timeout: 60_000 }, () => {
+    const result = runWorker({});
+
+    for (const trial of result.benchmarks) {
+      expect(trial.runs[0].stats.blocks).toBeUndefined();
+      expect(trial.runs[0].stats.samples.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('judges two blocked runs of the same code as neutral', { timeout: 120_000, retry: 2 }, () => {
+    const a = runWorker({ LABS_BLOCKS: '3' });
+    const b = runWorker({ LABS_BLOCKS: '3' });
+
+    const { verdict } = classify(
+      a.benchmarks[0].runs[0].stats.samples,
+      b.benchmarks[0].runs[0].stats.samples
+    );
+
+    expect(verdict).toBe('neutral');
+  });
+});

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { measure, B, bench, group, run } from '../src/bench/index.ts';
+import { hasUnstableSamples } from '../src/bench/types.ts';
 
 const fast = { min_cpu_time: 1, min_samples: 12, adaptive: false } as const;
 
@@ -54,7 +55,7 @@ describe('measuring work', () => {
     expectUsefulStats(stats);
   });
 
-  it('marks a run noisy when it cannot converge within its time budget', async () => {
+  it('marks samples unstable when they cannot converge within the time budget', async () => {
     const stats = await measure(() => {}, {
       min_cpu_time: 1,
       min_samples: 12,
@@ -62,7 +63,13 @@ describe('measuring work', () => {
       adaptive: 0.0001,
     });
 
+    expect(stats.samplesUnstable).toBe(true);
     expect(stats.noisy).toBe(true);
+  });
+
+  it('recognizes the deprecated stability field in older results', () => {
+    expect(hasUnstableSamples({ noisy: true })).toBe(true);
+    expect(hasUnstableSamples({ noisy: false })).toBe(false);
   });
 
   it('protects returned benchmark results from dead-code elimination', async () => {

--- a/tests/fixtures/blocks.bench.ts
+++ b/tests/fixtures/blocks.bench.ts
@@ -1,0 +1,15 @@
+import { bench, group } from '../../src/index.ts';
+
+bench('sum', () => {
+  let s = 0;
+  for (let i = 0; i < 1000; i++) s += i;
+  return s;
+});
+
+void group('blocked', () => {
+  bench('concat', () => {
+    let s = '';
+    for (let i = 0; i < 50; i++) s += i;
+    return s;
+  });
+});

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -27,9 +27,9 @@ describe('measurement report', () => {
 
   it('explains inconsistent runs and reports their comparison resolution', () => {
     const lines = captureReport(() =>
-      printReportBox([], [{ name: 'variable work', spread: 0.1 }], 5, undefined, undefined, {
-        blocks: 8,
-        spreads: [0.1],
+      printReportBox([], [{ name: 'variable work', runMedianSpread: 0.1 }], 5, undefined, undefined, {
+        freshRuns: 8,
+        medianSpreads: [0.1],
         minDelta: 0.05,
       })
     );
@@ -52,8 +52,8 @@ describe('measurement report', () => {
     const sampleLines = captureReport(() => printReportBox([], [], 5));
     const blockLines = captureReport(() =>
       printReportBox([], [], 5, undefined, undefined, {
-        blocks: 8,
-        spreads: [0.01],
+        freshRuns: 8,
+        medianSpreads: [0.01],
         minDelta: 0.05,
       })
     );
@@ -62,7 +62,7 @@ describe('measurement report', () => {
     expect(blockLines.some((line) => line.includes('✔ Consistent runs:'))).toBe(true);
   });
 
-  it('marks unstable rows without using the noisy legend', () => {
+  it('marks unstable rows without using the legacy terminology', () => {
     const lines: string[] = [];
     const noop = { avg: 0 };
     const stats = {
@@ -78,7 +78,7 @@ describe('measurement report', () => {
       p999: 102,
       ticks: 5,
       debug: '',
-      noisy: true,
+      samplesUnstable: true,
     };
 
     renderMitata(

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1,0 +1,117 @@
+import { stripVTControlCharacters } from 'node:util';
+import { describe, expect, it, vi } from 'vitest';
+import { renderMitata } from '../src/bench/render.ts';
+import { printReportBox } from '../src/report.ts';
+
+function captureReport(run: () => void): string[] {
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+  try {
+    run();
+    return log.mock.calls.map(([line]) => stripVTControlCharacters(String(line)));
+  } finally {
+    log.mockRestore();
+  }
+}
+
+describe('measurement report', () => {
+  it('explains unstable samples and lists the affected benchmarks', () => {
+    const lines = captureReport(() => printReportBox([], [{ name: 'random work' }], 5));
+
+    expect(lines).toContain(
+      '│  ⚠ Unstable samples: Timings did not settle suggesting non-deterministic work or runtime interference.  │'
+    );
+    expect(lines.some((line) => line.includes('Time limit: 5s.'))).toBe(true);
+    expect(lines.some((line) => line.includes('Affected benchmarks (1):'))).toBe(true);
+    expect(lines.some((line) => line.includes('⚠ random work'))).toBe(true);
+  });
+
+  it('explains inconsistent runs and reports their comparison resolution', () => {
+    const lines = captureReport(() =>
+      printReportBox([], [{ name: 'variable work', spread: 0.1 }], 5, undefined, undefined, {
+        blocks: 8,
+        spreads: [0.1],
+        minDelta: 0.05,
+      })
+    );
+
+    expect(
+      lines.some((line) =>
+        line.includes(
+          '⚠ Inconsistent runs: Median timings changed across fresh runs suggesting an unstable machine.'
+        )
+      )
+    ).toBe(true);
+    expect(lines.some((line) => line.includes('Median spread: ±10.0% across 8 fresh runs.'))).toBe(
+      true
+    );
+    expect(lines.some((line) => line.includes('Comparison resolution: ~±14.0%.'))).toBe(true);
+    expect(lines.some((line) => line.includes('Affected benchmarks (1):'))).toBe(true);
+  });
+
+  it('uses matching positive status labels for stable measurements', () => {
+    const sampleLines = captureReport(() => printReportBox([], [], 5));
+    const blockLines = captureReport(() =>
+      printReportBox([], [], 5, undefined, undefined, {
+        blocks: 8,
+        spreads: [0.01],
+        minDelta: 0.05,
+      })
+    );
+
+    expect(sampleLines.some((line) => line.includes('✔ Stable samples:'))).toBe(true);
+    expect(blockLines.some((line) => line.includes('✔ Consistent runs:'))).toBe(true);
+  });
+
+  it('marks unstable rows without using the noisy legend', () => {
+    const lines: string[] = [];
+    const noop = { avg: 0 };
+    const stats = {
+      kind: 'fn',
+      samples: [98, 99, 100, 101, 102],
+      min: 98,
+      max: 102,
+      avg: 100,
+      p25: 99,
+      p50: 100,
+      p75: 101,
+      p99: 102,
+      p999: 102,
+      ticks: 5,
+      debug: '',
+      noisy: true,
+    };
+
+    renderMitata(
+      {
+        cpu: { freq: 4, name: 'test-cpu' },
+        runtime: 'node',
+        version: 'test',
+        arch: 'test',
+        now: 0,
+        noop: { fn: noop, iter: noop, fn_gc: noop },
+      } as any,
+      { print: (line) => lines.push(line), colors: false },
+      [
+        {
+          name: null,
+          types: [],
+          trials: [
+            {
+              highlight: false,
+              compact: true,
+              gcMode: false,
+              bench: {
+                alias: 'random work',
+                runs: [{ name: 'random work', args: {}, stats }],
+              } as any,
+            },
+          ],
+        },
+      ]
+    );
+
+    expect(lines.some((line) => line.startsWith('⚠ random work'))).toBe(true);
+    expect(lines.some((line) => line.includes('noisy'))).toBe(false);
+    expect(lines.some((line) => line.startsWith('~'))).toBe(false);
+  });
+});

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { classify, mannWhitneyU, minMannWhitneyP } from '../src/stats.ts';
+import { classify, clockExplainedFraction, mannWhitneyU, minMannWhitneyP } from '../src/stats.ts';
 
 const samples = (value: number) => Array.from({ length: 30 }, () => value);
 
@@ -41,5 +41,44 @@ describe('mann-whitney on small samples', () => {
   it('derives the smallest attainable p-value from both sample sizes', () => {
     expect(minMannWhitneyP(4, 4)).toBeCloseTo(2 / 70, 10);
     expect(minMannWhitneyP(5, 5)).toBeCloseTo(2 / 252, 10);
+  });
+});
+
+describe('effect estimation', () => {
+  it('reports the hodges-lehmann delta with a degenerate CI for constant shifts', () => {
+    const result = classify(Array(5).fill(100), Array(5).fill(110));
+
+    expect(result.verdict).toBe('slower');
+    expect(result.hl).toBeCloseTo(0.1, 10);
+    expect(result.ciLow).toBeCloseTo(0.1, 10);
+    expect(result.ciHigh).toBeCloseTo(0.1, 10);
+  });
+
+  it('brackets the estimate with a widening interval under block noise', () => {
+    const baseline = [98, 100, 102, 99, 101, 100, 97, 103];
+    const candidate = baseline.map((v) => v * 1.2);
+
+    const result = classify(baseline, candidate);
+
+    expect(result.verdict).toBe('slower');
+    expect(result.ciLow).toBeLessThan(result.hl);
+    expect(result.ciHigh).toBeGreaterThan(result.hl);
+    expect(result.ciLow).toBeGreaterThan(0.05);
+  });
+});
+
+describe('clock attribution', () => {
+  const freqs = [4, 3.5, 4.2, 3.8, 4.1, 3.6];
+
+  it('attributes spread to the clock when medians track 1/frequency', () => {
+    const medians = freqs.map((f) => 400 / f);
+
+    expect(clockExplainedFraction(medians, freqs)).toBeCloseTo(1, 6);
+  });
+
+  it('attributes nothing to the clock when medians ignore it', () => {
+    const medians = [100, 101, 99, 100, 102, 98];
+
+    expect(clockExplainedFraction(medians, freqs)).toBe(0);
   });
 });

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { classify } from '../src/stats.ts';
+import { classify, mannWhitneyU } from '../src/stats.ts';
 
 const samples = (value: number) => Array.from({ length: 30 }, () => value);
 
@@ -17,5 +17,16 @@ describe('comparing benchmark results', () => {
 
   it('ignores differences below the meaningful-change threshold', () => {
     expect(classify(samples(100), samples(104)).verdict).toBe('neutral');
+  });
+});
+
+describe('mann-whitney on small samples', () => {
+  it('computes exact p-values for tie-free small samples', () => {
+    // Fully separated 5v5 has the smallest possible two-sided p of 2/252
+    expect(mannWhitneyU([1, 2, 3, 4, 5], [6, 7, 8, 9, 10]).p).toBeCloseTo(2 / 252, 6);
+  });
+
+  it('stays insignificant for interleaved small samples', () => {
+    expect(mannWhitneyU([1, 3, 5, 7, 9], [2, 4, 6, 8, 10]).p).toBeGreaterThan(0.5);
   });
 });

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { classify, clockExplainedFraction, mannWhitneyU, minMannWhitneyP } from '../src/stats.ts';
+import {
+  calibrationExplainedFraction,
+  classify,
+  mannWhitneyU,
+  minMannWhitneyP,
+} from '../src/stats.ts';
 
 const samples = (value: number) => Array.from({ length: 30 }, () => value);
 
@@ -54,7 +59,7 @@ describe('effect estimation', () => {
     expect(result.ciHigh).toBeCloseTo(0.1, 10);
   });
 
-  it('brackets the estimate with a widening interval under block noise', () => {
+  it('brackets the estimate with a widening interval under fresh-run variation', () => {
     const baseline = [98, 100, 102, 99, 101, 100, 97, 103];
     const candidate = baseline.map((v) => v * 1.2);
 
@@ -73,12 +78,12 @@ describe('clock attribution', () => {
   it('attributes spread to the clock when medians track 1/frequency', () => {
     const medians = freqs.map((f) => 400 / f);
 
-    expect(clockExplainedFraction(medians, freqs)).toBeCloseTo(1, 6);
+    expect(calibrationExplainedFraction(medians, freqs)).toBeCloseTo(1, 6);
   });
 
   it('attributes nothing to the clock when medians ignore it', () => {
     const medians = [100, 101, 99, 100, 102, 98];
 
-    expect(clockExplainedFraction(medians, freqs)).toBe(0);
+    expect(calibrationExplainedFraction(medians, freqs)).toBe(0);
   });
 });

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { classify, mannWhitneyU } from '../src/stats.ts';
+import { classify, mannWhitneyU, minMannWhitneyP } from '../src/stats.ts';
 
 const samples = (value: number) => Array.from({ length: 30 }, () => value);
 
@@ -28,5 +28,18 @@ describe('mann-whitney on small samples', () => {
 
   it('stays insignificant for interleaved small samples', () => {
     expect(mannWhitneyU([1, 3, 5, 7, 9], [2, 4, 6, 8, 10]).p).toBeGreaterThan(0.5);
+  });
+
+  it('computes exact permutation p-values when small samples contain ties', () => {
+    const baseline = [100, 100, 110, 110, 110];
+    const candidate = [110, 110, 120, 120, 120];
+
+    expect(mannWhitneyU(baseline, candidate).p).toBeCloseTo(20 / 252, 6);
+    expect(classify(baseline, candidate).verdict).toBe('neutral');
+  });
+
+  it('derives the smallest attainable p-value from both sample sizes', () => {
+    expect(minMannWhitneyP(4, 4)).toBeCloseTo(2 / 70, 10);
+    expect(minMannWhitneyP(5, 5)).toBeCloseTo(2 / 252, 10);
   });
 });

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Stats } from '../src/bench/types.ts';
 import {
   type SavedResult,
   deleteResult,
@@ -9,6 +10,7 @@ import {
   loadResult,
   resultExists,
   saveResult,
+  trimStats,
   uniqueResultName,
 } from '../src/store.ts';
 
@@ -65,5 +67,25 @@ describe('saved benchmark results', () => {
 
     saveResult(labsDir, result('main-2'));
     expect(uniqueResultName(labsDir, 'main')).toBe('main-3');
+  });
+
+  it('saves the explicit sample stability field with its legacy alias', () => {
+    const stats = {
+      kind: 'fn',
+      samples: [100],
+      min: 100,
+      max: 100,
+      avg: 100,
+      p25: 100,
+      p50: 100,
+      p75: 100,
+      p99: 100,
+      p999: 100,
+      ticks: 1,
+      debug: '',
+      samplesUnstable: true,
+    } satisfies Stats;
+
+    expect(trimStats(stats)).toMatchObject({ samplesUnstable: true, noisy: true });
   });
 });


### PR DESCRIPTION
This PR moves lab's statistical strategy to block interleaving. 

:- Each saved benchmark is measured in eight fresh-process blocks. Within one benchmark file, the blocks are interleaved:`A₁ B₁ C₁ → A₂ B₂ C₂ → … → A₈ B₈ C₈`
- Interleaving spreads every benchmark across roughly the same time window. This reduces bias from gradual changes such as CPU throttling or even boosting.
- Each block gets is on its own VM for full isolation and each sample runs GC before and after to control measurements.
- A probe at the beginning of the bench decides if the blocks should run with batching or not. Batching is used if the measurement is so fast that the timing overhead would drown out its results. 
- This makes the measurement of variance much more reliable.

If the spread between blocks in a benchmark are too large then it gets flagged as noisy. The minimum resolution that can be reliably detected is then calculated from the spread. This limits how small the change can be where the change can be detected.

The comparison strategy becomes more robust as well. Labs takes two runs of block measurements:
`Baseline:  A₁ A₂ A₃ … A₈Candidate: A₁ A₂ A₃ … A₈`

And asks:
1. Is the difference consistent? It uses a Mann–Whitney rank test on the two sets of block medians. If candidate blocks are consistently slower than baseline blocks, the p-value becomes small. The default requirement is p ≤ 0.05.2.
2.  Is the difference large enough to matter? Labs estimates the typical relative change using all block pairs. The default requirement is at least 5% or it gets flagged as neutral.The baseline and candidate are compared as two sets of independent groups. The main measurement is the Δp50 with the Δ CI indicating uncertainty.